### PR TITLE
fix bug with separator rule

### DIFF
--- a/src/main/java/cli/rule/rules/SeparatorRule.java
+++ b/src/main/java/cli/rule/rules/SeparatorRule.java
@@ -84,6 +84,11 @@ public class SeparatorRule implements IRestRule {
         for (String path : pathList) {
             Output.progressPercentage(curPath, totalPaths);
             curPath++;
+            // if the path is the root path, skip it
+            // see https://github.com/restful-ma/rest-ruler/issues/54 for more information
+            if (path.equals("/")) {
+                continue;
+            }
 
             Matcher matcher = expectedPattern.matcher(path);
 

--- a/src/test/java/cli/rule/separatorTests/SeparatorRuleTest.java
+++ b/src/test/java/cli/rule/separatorTests/SeparatorRuleTest.java
@@ -65,8 +65,6 @@ class SeparatorRuleTest {
         input.add("=v1={destination_definitions}=create");
         input.add("=v1=destination_definitions=create");
 
-        input.add("/");
-
         //run Method under test
         runMethodUnderTest(input);
 

--- a/src/test/java/cli/rule/separatorTests/separator_test.json
+++ b/src/test/java/cli/rule/separatorTests/separator_test.json
@@ -89,6 +89,16 @@
     }
   ],
   "paths": {
+    "/": {
+      "get": {
+        "description": "Root endpoint",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/v1/connections/create": {
       "post": {
         "operationId": "createConnection",
@@ -2406,5 +2416,4 @@
       }
     }
   }
-}
 }


### PR DESCRIPTION
# Description

The rule "Forward slash separator (/) must be used to indicate a hierarchical relationship" incorrectly flags the root path "/" as a violation, however as explained in #52 and #54, this behavior is not correct and a path with a single slash is valid.

Fixes #54 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [ ] Unit tests (CI)
