### PR TITLE
feat: add optional camelCase naming convention rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -50,6 +50,7 @@ Documentation about the rules can be found in the [folder](./implemented-rules).
 * [A plural noun should be used for collection or store names](./implemented-rules/A-plural-noun-should-be-used-for-collection-or-store-names.md)
 * [A singular noun should be used for document names](./implemented-rules/A-singular-noun-should-be-used-for-document-names.md)
 * [A verb or verb phrase should be used for controller names](./implemented-rules/A-verb-or-verb-phrase-should-be-used-for-controller-names.md)
+* [Camel case should be used (optional)](./implemented-rules/Camel-case-should-be-used.md)
 
 ### Rule implementation and extension
 For each rule, a single Java class is created, which can be found in in this [dir](../../src/main/java/cli/rule/rules). It is just as easy to implement a new rule. For implementing a new rule, it is merely necessary to create a Java class in the folder just mentioned, which implements the [`IRestRule`](../../src/main/java/cli/rule/IRestRule.java) interface. Then, a constructor with an `isActive` boolean is needed. Now the rule is automatically recognized and listed in the CLI. This is the minimum that needs to be done to implement a new rule. 

--- a/docs/rules/implemented-rules/Camel-case-should-be-used.md
+++ b/docs/rules/implemented-rules/Camel-case-should-be-used.md
@@ -1,0 +1,44 @@
+# Hyphens should be used to improve the readability of URIs
+
+## Category
+
+URIs
+
+## Importance, severity, difficulty
+
+* Importance: medium
+* Severity: error
+* Difficulty to implement the rule: medium
+
+## Quality Attribute
+
+* Maintainability
+* Compatibility
+
+## Rule Description
+
+This rule is implemented to allow users to have a choice in selecting which naming convention they want the tool to check. If the developers of the API opted to follow the camelCase naming convention for their URIs, they can configure the tool to check for conformance to this convention in each URI. Otherwise, the tool will check for conformance to the usage of hyphens and lowercase letters in the URIs by default.
+
+## Implemented
+
+* Yes
+
+## Implementation Details
+
+* Check if a path segment can be reduced to more than one word. If yes and the path segment does not capitalize every word except the first one, there is a violation
+* Give the hint to use camelCase in each URI, to keep the API consistent
+
+### What is checked:
+
+* extract path segments from path using "/" as delimiter
+* based on an English dictionary, the extracted path is checked for substrings. If one or more substrings are found, and each word except the first is not capitalized, a violation is reported
+* pathSegment can be camelCase, kebabCase, snakeCase, all lowercase, all uppercase, or just a mixture of these
+
+### What is not checked:
+
+* presence of invalid delimiters
+* check of dynamic parameters
+
+### Future work
+
+* Use a bigger dictionary with a caching possibility to improve performance and precision.

--- a/docs/rules/implemented-rules/Camel-case-should-be-used.md
+++ b/docs/rules/implemented-rules/Camel-case-should-be-used.md
@@ -1,4 +1,4 @@
-# Hyphens should be used to improve the readability of URIs
+# Camel case should be used to improve the readability of URIs
 
 ## Category
 
@@ -32,7 +32,7 @@ This rule is implemented to allow users to have a choice in selecting which nami
 
 * extract path segments from path using "/" as delimiter
 * based on an English dictionary, the extracted path is checked for substrings. If one or more substrings are found, and each word except the first is not capitalized, a violation is reported
-* pathSegment can be camelCase, kebabCase, snakeCase, all lowercase, all uppercase, or just a mixture of these
+* pathSegment can be camelCase, kebab-case, snake_case, all lowercase, all uppercase, or just a mixture of these
 
 ### What is not checked:
 

--- a/src/main/java/cli/RestRulerCli.java
+++ b/src/main/java/cli/RestRulerCli.java
@@ -24,6 +24,10 @@ public class RestRulerCli implements Runnable {
             description = "Specify a custom filename for the Markdown report")
     private String filename;
 
+    @Option(names = {"-n", "--naming"}, 
+            description = "Specify the naming convention to use (camelcase or kebabcase). Default is kebabcase.")
+    private String namingConvention;
+
     public static void main(String[] args) {
         PicocliRunner.run(RestRulerCli.class, args);
     }
@@ -36,6 +40,12 @@ public class RestRulerCli implements Runnable {
         if (this.expertMode)
             output.askActiveRules();
         if (this.openApiPath != null) {
+            // Set naming convention rules based on the flag
+            if (namingConvention != null && namingConvention.equalsIgnoreCase("camelcase")) {
+                output.setNamingConventionRules(true);
+            } else {
+                output.setNamingConventionRules(false);
+            }
 
             if (filename != null)
                 output.startAnalysis(this.openApiPath, this.filename);

--- a/src/main/java/cli/rule/IRestRule.java
+++ b/src/main/java/cli/rule/IRestRule.java
@@ -2,6 +2,7 @@ package cli.rule;
 
 import cli.rule.constants.RuleCategory;
 import cli.rule.constants.RuleSeverity;
+import cli.rule.constants.RuleIdentifier;
 import cli.rule.constants.RuleSoftwareQualityAttribute;
 import io.swagger.v3.oas.models.OpenAPI;
 
@@ -10,6 +11,8 @@ import java.util.List;
 public interface IRestRule {
 
     String getTitle();
+
+    RuleIdentifier getIdentifier();
 
     RuleCategory getCategory();
 

--- a/src/main/java/cli/rule/constants/ErrorMessage.java
+++ b/src/main/java/cli/rule/constants/ErrorMessage.java
@@ -22,6 +22,7 @@ public class ErrorMessage {
     public static final String REQUESTTYPE = "Type of the request does not match with the description of the request";
     public static final String REQUESTTYPETUNNELINGGET = "This request is performing more than one action. GET request should not be used to tunnel other request";
     public static final String REQUESTTYPETUNNELINGPOST = "This request is performing more than one action. POST request should not be used to tunnel other request";
+    public static final String CAMELCASE = "Multi-word URI segment does not follow camelCase convention";
 
 
     private ErrorMessage() {

--- a/src/main/java/cli/rule/constants/ImprovementSuggestion.java
+++ b/src/main/java/cli/rule/constants/ImprovementSuggestion.java
@@ -21,6 +21,7 @@ public class ImprovementSuggestion {
     public static final String REQUESTTYPETUNELING = " GET and POST must not be used to tunnel other request methods";
     public static final String VERB_PHRASE = "Use a verb or verb phrase for controller names";
     public static final String TRAILING_SLASH = "remove trailing forward slash '/' from URI";
+    public static final String CAMELCASE = "Use camelCase to separate words in URI segments";
 
     private ImprovementSuggestion() {
         throw new IllegalStateException("Utility class");

--- a/src/main/java/cli/rule/constants/RuleIdentifier.java
+++ b/src/main/java/cli/rule/constants/RuleIdentifier.java
@@ -1,0 +1,20 @@
+package cli.rule.constants;
+
+public enum RuleIdentifier {
+    CAMEL_CASE, 
+    CONTENT_TYPE, 
+    CRUD, 
+    FILE_EXTENSION, 
+    GET_RESOURCE, 
+    HYPHENS, 
+    LOWERCASE, 
+    PLURAL_NAME,
+    REQUEST_TYPE_DESCRIPTION,
+    SEPARATOR,
+    SINGULAR_DOCUMENT_NAME,
+    TRAILING,
+    TUNNELING,
+    UNAUTHORIZED,
+    UNDERSCORE,
+    VERB_PHRASE
+}

--- a/src/main/java/cli/rule/rules/CRUDRule.java
+++ b/src/main/java/cli/rule/rules/CRUDRule.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import cli.rule.constants.*;
 import java.util.Set;
 import cli.analyzer.RestAnalyzer;
 import cli.rule.IRestRule;
@@ -21,6 +22,7 @@ import io.swagger.v3.oas.models.OpenAPI;
  */
 public class CRUDRule implements IRestRule {
     private static final String TITLE = "CRUD function names should not be used in URIs";
+    private static final RuleIdentifier RULE_IDENTIFIER = RuleIdentifier.CRUD;
     private static final RuleCategory CATEGORY = RuleCategory.URIS;
     private static final RuleSeverity SEVERITY = RuleSeverity.ERROR;
     private static final List<RuleSoftwareQualityAttribute> SOFTWARE_QUALITY_ATTRIBUTE =
@@ -39,6 +41,11 @@ public class CRUDRule implements IRestRule {
     @Override
     public String getTitle() {
         return TITLE;
+    }
+
+    @Override
+    public RuleIdentifier getIdentifier() {
+        return RULE_IDENTIFIER;
     }
 
     @Override

--- a/src/main/java/cli/rule/rules/CamelCaseRule.java
+++ b/src/main/java/cli/rule/rules/CamelCaseRule.java
@@ -4,54 +4,33 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import com.google.common.collect.Lists;
+
 import cli.analyzer.RestAnalyzer;
 import cli.rule.IRestRule;
 import cli.rule.Utility;
 import cli.rule.Violation;
-import cli.rule.constants.ErrorMessage;
-import cli.rule.constants.ImprovementSuggestion;
-import cli.rule.constants.RuleCategory;
-import cli.rule.constants.RuleSeverity;
-import cli.rule.constants.RuleSoftwareQualityAttribute;
+import cli.rule.constants.*;
 import cli.utility.Output;
 import io.swagger.v3.oas.models.OpenAPI;
-import cli.rule.constants.RuleIdentifier;
 
-public class HyphensRule implements IRestRule {
+public class CamelCaseRule implements IRestRule {
 
     private static final String PATH_TO_ENGLISH_DICTIONARY = "/wordninja_words.txt";
-
-    private static final String TITLE =
-            "Hyphens (-) should be used to improve the readability of URIs";
-    private static final RuleIdentifier RULE_IDENTIFIER = RuleIdentifier.HYPHENS;
+    private static final String TITLE = "CamelCase should be used for multi-word URI segments";
+    private static final RuleIdentifier RULE_IDENTIFIER = RuleIdentifier.CAMEL_CASE;
     private static final RuleCategory RULE_CATEGORY = RuleCategory.URIS;
     private static final RuleSeverity RULE_SEVERITY = RuleSeverity.ERROR;
-    private static final List<RuleSoftwareQualityAttribute> RULE_SOFTWARE_QUALITY_ATTRIBUTE_LIST =
-            List.of(RuleSoftwareQualityAttribute.COMPATIBILITY,
-                    RuleSoftwareQualityAttribute.MAINTAINABILITY);
+    private static final List<RuleSoftwareQualityAttribute> RULE_SOFTWARE_QUALITY_ATTRIBUTE_LIST = List
+            .of(RuleSoftwareQualityAttribute.COMPATIBILITY, RuleSoftwareQualityAttribute.MAINTAINABILITY);
     private final Logger logger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
     private boolean isActive;
 
-    public HyphensRule(boolean isActive) {
+    public CamelCaseRule(boolean isActive) {
         this.isActive = isActive;
-    }
-
-    @Override
-    public RuleIdentifier getIdentifier() {
-        return RULE_IDENTIFIER;
     }
 
     @Override
@@ -60,8 +39,13 @@ public class HyphensRule implements IRestRule {
     }
 
     @Override
+    public RuleIdentifier getIdentifier() {
+        return RULE_IDENTIFIER;
+    }
+
+    @Override
     public RuleCategory getCategory() {
-        return HyphensRule.RULE_CATEGORY;
+        return RULE_CATEGORY;
     }
 
     @Override
@@ -84,17 +68,9 @@ public class HyphensRule implements IRestRule {
         this.isActive = isActive;
     }
 
-    /**
-     * Rule to check if the path segments could contain more than one word, if so there is a
-     * violation.
-     *
-     * @param openAPI
-     */
     @Override
     public List<Violation> checkViolation(OpenAPI openAPI) {
         List<Violation> violations = new ArrayList<>();
-
-        // Get the paths from the OpenAPI object
         Set<String> paths = openAPI.getPaths().keySet();
 
         if (paths.isEmpty())
@@ -128,55 +104,79 @@ public class HyphensRule implements IRestRule {
                 continue;
             if (pathSegment.contains("\\"))
                 continue;
-            boolean isPathFullyContained;
 
-            isPathFullyContained =
-                    Utility.getPathSegmentMatch(pathSegment, PATH_TO_ENGLISH_DICTIONARY);
+            // Check if the segment contains any separators (hyphens or underscores)
+            if (pathSegment.contains("-") || pathSegment.contains("_")) {
+                return new Violation(this, RestAnalyzer.locMapper.getLOCOfPath(path),
+                        ImprovementSuggestion.CAMELCASE, 
+                        path, ErrorMessage.CAMELCASE);
+            }
 
+            // First check if the segment starts with uppercase (violation)
+            if (Character.isUpperCase(pathSegment.charAt(0))) {
+                return new Violation(this, RestAnalyzer.locMapper.getLOCOfPath(path),
+                        ImprovementSuggestion.CAMELCASE, 
+                        path, ErrorMessage.CAMELCASE);
+            }
+
+            boolean isPathFullyContained = Utility.getPathSegmentMatch(pathSegment, PATH_TO_ENGLISH_DICTIONARY);
             if (isPathFullyContained)
                 continue;
-            List<String> itemsFromHyphens = Arrays.asList(pathSegment.split("-"));
-            List<String> itemsFromUnderscore = Arrays.asList(pathSegment.split("_"));
-            // Math the segment path based on the regex. This solution is very fast to run
-            List<String> pathWithoutParameters = Arrays
-                    .asList(pathSegment.split("(?<!(^|[A-Z]))(?=[A-Z])|(?<!^)" + "(?=[A-Z][a-z])"));
-
-            if (pathWithoutParameters.size() > 1) {
-                return new Violation(this, RestAnalyzer.locMapper.getLOCOfPath(path),
-                        ImprovementSuggestion.HYPHEN, path, ErrorMessage.HYPHEN);
+    
+            List<String> itemsFromCamelCase = Arrays.asList(
+                    pathSegment.split("(?<!(^|[A-Z]))(?=[A-Z])|(?<!^)(?=[A-Z][a-z])"));
+    
+            if (itemsFromCamelCase.size() > 1) {
+                // multiple words detected, check if camelCase
+                if (!isValidCamelCase(pathSegment, itemsFromCamelCase)) {
+                    return new Violation(this, RestAnalyzer.locMapper.getLOCOfPath(path),
+                            ImprovementSuggestion.CAMELCASE, path, ErrorMessage.CAMELCASE);
+                }
+                continue;
             }
-
-            // If with the regex no substring was found then we need to check against a
-            // dictionary of english words
+    
             try {
                 List<String> subStringFromPath = splitContiguousWords(pathSegment);
-                List<String> pathWithoutParameterDictionaryMatching =
+                List<String> pathFromDictionary =
                         Arrays.asList(subStringFromPath.get(0).split(" "));
-                // If the path is correct and the matching regex creates the same split with the
-                // "-" as split, then
-                // continue with the next segment path
-                if (itemsFromHyphens.equals(pathWithoutParameterDictionaryMatching)
-                        || itemsFromHyphens.equals(subStringFromPath)
-                        || subStringFromPath.equals(itemsFromUnderscore))
-                    continue;
-                // Add violations if there is some match
-                return new Violation(this, RestAnalyzer.locMapper.getLOCOfPath(path),
-                        ImprovementSuggestion.HYPHEN, path, ErrorMessage.HYPHEN);
+    
+                if (pathFromDictionary.size() > 1) {
+                    // Check if not camelCase
+                    if (!isValidCamelCaseForDictionaryWords(pathSegment, pathFromDictionary)) {
+                        return new Violation(this, RestAnalyzer.locMapper.getLOCOfPath(path),
+                                ImprovementSuggestion.CAMELCASE, path, ErrorMessage.CAMELCASE);
+                    }
+                }
             } catch (IOException e) {
-                logger.log(Level.SEVERE, "Error on checking substring against a dictionary{e}", e);
+                logger.log(Level.SEVERE, "Error checking segment against dictionary", e);
             }
-
         }
         return null;
+    }    
+
+    private boolean isValidCamelCase(String segment, List<String> words) {
+        // First word should be lowercase
+        if (!Character.isLowerCase(segment.charAt(0)))
+            return false;
+
+        // For each word after the first, check if it starts with uppercase
+        int currentPos = 0;
+        for (int i = 1; i < words.size(); i++) {
+            String word = words.get(i);
+            currentPos = segment.indexOf(word, currentPos);
+            if (currentPos == -1 || !Character.isUpperCase(segment.charAt(currentPos)))
+                return false;
+            currentPos += word.length();
+        }
+
+        return true;
     }
 
-    public List<String> splitContiguousWords(String sentence) throws IOException {
-
+    private List<String> splitContiguousWords(String sentence) throws IOException {
         String splitRegex = "[^a-zA-Z0-9']+";
         Map<String, Number> wordCost = new HashMap<>();
         List<String> dictionaryWords = new ArrayList<>();
         InputStream is = null;
-
 
         try {
             is = Utility.class.getResourceAsStream(PATH_TO_ENGLISH_DICTIONARY);
@@ -195,8 +195,8 @@ public class HyphensRule implements IRestRule {
         for (String word : dictionaryWords) {
             wordCost.put(word, Math.log(++wordIdx * naturalLogDictionaryWordsCount));
         }
-        int maxWordLength =
-                Collections.max(dictionaryWords, Comparator.comparing(String::length)).length();
+
+        int maxWordLength = Collections.max(dictionaryWords, Comparator.comparing(String::length)).length();
         List<String> splitWords = new ArrayList<>();
         for (String partSentence : sentence.split(splitRegex)) {
             splitWords.add(split(partSentence, wordCost, maxWordLength));
@@ -205,59 +205,71 @@ public class HyphensRule implements IRestRule {
     }
 
     private String split(String partSentence, Map<String, Number> wordCost, int maxWordLength) {
-        List<ImmutablePair<Number, Number>> cost = new ArrayList<>();
-        cost.add(new ImmutablePair<>(0, 0));
-        for (int index = 1; index < partSentence.length() + 1; index++) {
+        List<Map.Entry<Number, Number>> cost = new ArrayList<>();
+        cost.add(new AbstractMap.SimpleEntry<>(0, 0));
+        
+        for (int index = 1; index <= partSentence.length(); index++) {
             cost.add(bestMatch(partSentence, cost, index, wordCost, maxWordLength));
         }
+
         int idx = partSentence.length();
         List<String> output = new ArrayList<>();
+        
         while (idx > 0) {
-            ImmutablePair<Number, Number> candidate =
-                    bestMatch(partSentence, cost, idx, wordCost, maxWordLength);
+            Map.Entry<Number, Number> candidate = bestMatch(partSentence, cost, idx, wordCost, maxWordLength);
             Number candidateCost = candidate.getKey();
             Number candidateIndexValue = candidate.getValue();
-            if (candidateCost.doubleValue() != cost.get(idx).getKey().doubleValue())
+            
+            if (candidateCost.doubleValue() != cost.get(idx).getKey().doubleValue()) {
                 logger.log(Level.SEVERE, "Candidate cost unmatched; This should not be the case!");
-            boolean newToken = true;
+            }
+            
             String token = partSentence.substring(idx - candidateIndexValue.intValue(), idx);
-            if (token.equals("'") && !output.isEmpty()) {
-                String lastWord = output.get(output.size() - 1);
-                if (lastWord.equalsIgnoreCase("'s")
-                        || (Character.isDigit(partSentence.charAt(idx - 1))
-                                && Character.isDigit(lastWord.charAt(0)))) {
-                    output.set(output.size() - 1, token + lastWord);
-                    newToken = false;
-                }
-            }
-            if (newToken) {
-                output.add(token);
-            }
+            output.add(token);
             idx -= candidateIndexValue.intValue();
         }
-        return String.join(" ", Lists.reverse(output));
+        
+        return String.join(" ", output);
     }
 
-    private ImmutablePair<Number, Number> bestMatch(String partSentence,
-            List<ImmutablePair<Number, Number>> cost, int index, Map<String, Number> wordCost,
-            int maxWordLength) {
-        List<ImmutablePair<Number, Number>> candidates =
-                Lists.reverse(cost.subList(Math.max(0, index - maxWordLength), index));
+    private Map.Entry<Number, Number> bestMatch(String partSentence, List<Map.Entry<Number, Number>> cost, 
+            int index, Map<String, Number> wordCost, int maxWordLength) {
+        List<Map.Entry<Number, Number>> candidates = new ArrayList<>(cost.subList(
+            Math.max(0, index - maxWordLength), index));
+        Collections.reverse(candidates);
+        
         int enumerateIdx = 0;
-        ImmutablePair<Number, Number> minPair =
-                new ImmutablePair<>(Integer.MAX_VALUE, enumerateIdx);
-        for (ImmutablePair<Number, Number> pair : candidates) {
+        Map.Entry<Number, Number> minPair = new AbstractMap.SimpleEntry<>(Integer.MAX_VALUE, enumerateIdx);
+        
+        for (Map.Entry<Number, Number> pair : candidates) {
             ++enumerateIdx;
             String subsequence = partSentence.substring(index - enumerateIdx, index).toLowerCase();
             Number minCost = Integer.MAX_VALUE;
+            
             if (wordCost.containsKey(subsequence)) {
                 minCost = pair.getKey().doubleValue() + wordCost.get(subsequence).doubleValue();
             }
+            
             if (minCost.doubleValue() < minPair.getKey().doubleValue()) {
-                minPair = new ImmutablePair<>(minCost.doubleValue(), enumerateIdx);
+                minPair = new AbstractMap.SimpleEntry<>(minCost.doubleValue(), enumerateIdx);
             }
         }
+        
         return minPair;
     }
 
-}
+    private boolean isValidCamelCaseForDictionaryWords(String segment, List<String> words) {
+        if (words.size() <= 1) return true;
+        
+        // Build expected camelCase version
+        StringBuilder expectedCamelCase = new StringBuilder();
+        expectedCamelCase.append(words.get(0).toLowerCase());
+        
+        for (int i = 1; i < words.size(); i++) {
+            String word = words.get(i);
+            expectedCamelCase.append(Character.toUpperCase(word.charAt(0))).append(word.substring(1).toLowerCase());
+        }
+        
+        return segment.equals(expectedCamelCase.toString());
+    }
+} 

--- a/src/main/java/cli/rule/rules/ContentTypeRule.java
+++ b/src/main/java/cli/rule/rules/ContentTypeRule.java
@@ -26,6 +26,7 @@ import java.util.logging.Logger;
 public class ContentTypeRule implements IRestRule {
 
     private static final String TITLE = "Content-Type must be used";
+    private static final RuleIdentifier RULE_IDENTIFIER = RuleIdentifier.CONTENT_TYPE;
     private static final RuleCategory CATEGORY = RuleCategory.META;
     private static final RuleSeverity SEVERITY = RuleSeverity.CRITICAL;
     private static final List<RuleSoftwareQualityAttribute> SOFTWARE_QUALITY_ATTRIBUTE = Arrays
@@ -50,6 +51,11 @@ public class ContentTypeRule implements IRestRule {
     @Override
     public String getTitle() {
         return TITLE;
+    }
+
+    @Override
+    public RuleIdentifier getIdentifier() {
+        return RULE_IDENTIFIER;
     }
 
     @Override

--- a/src/main/java/cli/rule/rules/FileExtensionRule.java
+++ b/src/main/java/cli/rule/rules/FileExtensionRule.java
@@ -12,6 +12,7 @@ import java.util.logging.Logger;
 import cli.analyzer.RestAnalyzer;
 import cli.rule.IRestRule;
 import cli.rule.Violation;
+import cli.rule.constants.*;
 import cli.rule.constants.ErrorMessage;
 import cli.rule.constants.RuleCategory;
 import cli.rule.constants.RuleSeverity;
@@ -22,6 +23,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 public class FileExtensionRule implements IRestRule {
     private static final String PATH_TO_FILE_EXTENSIONS = "/file_extensions.txt";
     private static final String TITLE = "File extensions should not be included in URIs";
+    private static final RuleIdentifier RULE_IDENTIFIER = RuleIdentifier.FILE_EXTENSION;
     private static final RuleCategory CATEGORY = RuleCategory.URIS;
     private static final RuleSeverity SEVERITY = RuleSeverity.ERROR;
     private static final List<RuleSoftwareQualityAttribute> SOFTWARE_QUALITY_ATTRIBUTES =
@@ -39,6 +41,12 @@ public class FileExtensionRule implements IRestRule {
     public String getTitle() {
         return TITLE;
     }
+
+    @Override
+    public RuleIdentifier getIdentifier() {
+        return RULE_IDENTIFIER;
+    }
+
 
     @Override
     public RuleCategory getCategory() {

--- a/src/main/java/cli/rule/rules/GetResourceRule.java
+++ b/src/main/java/cli/rule/rules/GetResourceRule.java
@@ -24,6 +24,7 @@ public class GetResourceRule implements IRestRule {
 
     //Rule Attribute Definitions
     private static final String TITLE = "GET must be used to retrieve a representation of a resource";
+    private static final RuleIdentifier RULE_IDENTIFIER = RuleIdentifier.GET_RESOURCE;
     private static final RuleCategory RULE_CATEGORY = RuleCategory.HTTP;
     private static final RuleSeverity RULE_SEVERITY = RuleSeverity.CRITICAL;
     private static final List<RuleSoftwareQualityAttribute> SOFTWARE_QUALITY_ATTRIBUTES =
@@ -40,6 +41,11 @@ public class GetResourceRule implements IRestRule {
     @Override
     public String getTitle() {
         return TITLE;
+    }
+
+    @Override
+    public RuleIdentifier getIdentifier() {
+        return RULE_IDENTIFIER;
     }
 
     @Override

--- a/src/main/java/cli/rule/rules/LowercaseRule.java
+++ b/src/main/java/cli/rule/rules/LowercaseRule.java
@@ -15,6 +15,7 @@ import static cli.analyzer.RestAnalyzer.locMapper;
 public class LowercaseRule implements IRestRule {
 
     private static final String TITLE = "Lowercase letters should be preferred in URI paths";
+    private static final RuleIdentifier RULE_IDENTIFIER = RuleIdentifier.LOWERCASE;
     private static final RuleCategory RULE_CATEGORY = RuleCategory.URIS;
     private static final RuleSeverity RULE_SEVERITY = RuleSeverity.ERROR;
     private static final List<RuleSoftwareQualityAttribute> RULE_SOFTWARE_QUALITY_ATTRIBUTE_LIST = List
@@ -23,6 +24,11 @@ public class LowercaseRule implements IRestRule {
 
     public LowercaseRule(boolean isActive) {
         this.isActive = isActive;
+    }
+
+    @Override
+    public RuleIdentifier getIdentifier() {
+        return RULE_IDENTIFIER;
     }
 
     @Override

--- a/src/main/java/cli/rule/rules/PluralNameRule.java
+++ b/src/main/java/cli/rule/rules/PluralNameRule.java
@@ -14,6 +14,7 @@ import static cli.rule.Utility.*;
 public class PluralNameRule implements IRestRule {
 
     public static final String WITH_PATH_SEGMENT = " With pathSegment: ";
+    private static final RuleIdentifier RULE_IDENTIFIER = RuleIdentifier.PLURAL_NAME;
     private static final String TITLE = "A plural noun should be used for collection or store names";
     private static final RuleCategory RULE_CATEGORY = RuleCategory.URIS;
     private static final RuleSeverity RULE_SEVERITY = RuleSeverity.ERROR;
@@ -28,6 +29,11 @@ public class PluralNameRule implements IRestRule {
     @Override
     public String getTitle() {
         return TITLE;
+    }
+
+    @Override
+    public RuleIdentifier getIdentifier() {
+        return RULE_IDENTIFIER;
     }
 
     @Override

--- a/src/main/java/cli/rule/rules/RequestTypeDescriptionRule.java
+++ b/src/main/java/cli/rule/rules/RequestTypeDescriptionRule.java
@@ -15,6 +15,7 @@ import java.util.Set;
 
 public class RequestTypeDescriptionRule implements IRestRule {
     static final String TITLE = "Description of request should match with the type of the request.";
+    private static final RuleIdentifier RULE_IDENTIFIER = RuleIdentifier.REQUEST_TYPE_DESCRIPTION;
     static final RuleCategory RULE_CATEGORY = RuleCategory.META;
     static final RuleSeverity RULE_SEVERITY = RuleSeverity.WARNING;
     static final List<RuleSoftwareQualityAttribute> SOFTWARE_QUALITY_ATTRIBUTES = List.of(RuleSoftwareQualityAttribute.MAINTAINABILITY);
@@ -29,6 +30,11 @@ public class RequestTypeDescriptionRule implements IRestRule {
     @Override
     public String getTitle() {
         return TITLE;
+    }
+
+    @Override
+    public RuleIdentifier getIdentifier() {
+        return RULE_IDENTIFIER;
     }
 
     @Override

--- a/src/main/java/cli/rule/rules/SeparatorRule.java
+++ b/src/main/java/cli/rule/rules/SeparatorRule.java
@@ -19,6 +19,7 @@ import static cli.analyzer.RestAnalyzer.locMapper;
 public class SeparatorRule implements IRestRule {
 
     static final String TITLE = "Forward slash separator (/) must be used to indicate a hierarchical relationship";
+    private static final RuleIdentifier RULE_IDENTIFIER = RuleIdentifier.SEPARATOR;
     static final RuleCategory RULE_CATEGORY = RuleCategory.URIS;
     static final RuleSeverity RULE_SEVERITY = RuleSeverity.CRITICAL;
     static final List<RuleSoftwareQualityAttribute> SOFTWARE_QUALITY_ATTRIBUTES = List
@@ -34,6 +35,11 @@ public class SeparatorRule implements IRestRule {
     @Override
     public String getTitle() {
         return TITLE;
+    }
+
+    @Override
+    public RuleIdentifier getIdentifier() {
+        return RULE_IDENTIFIER;
     }
 
     @Override

--- a/src/main/java/cli/rule/rules/SingularDocumentNameRule.java
+++ b/src/main/java/cli/rule/rules/SingularDocumentNameRule.java
@@ -15,6 +15,7 @@ import static cli.rule.Utility.*;
 public class SingularDocumentNameRule implements IRestRule {
 
     public static final String WITH_PATH_SEGMENT = " With pathSegment: ";
+    private static final RuleIdentifier RULE_IDENTIFIER = RuleIdentifier.SINGULAR_DOCUMENT_NAME;
     private static final String TITLE = "A singular noun should be used for document names";
     private static final RuleCategory RULE_CATEGORY = RuleCategory.URIS;
     private static final RuleSeverity RULE_SEVERITY = RuleSeverity.ERROR;
@@ -30,6 +31,11 @@ public class SingularDocumentNameRule implements IRestRule {
 
     public String getTitle() {
         return TITLE;
+    }
+
+    @Override
+    public RuleIdentifier getIdentifier() {
+        return RULE_IDENTIFIER;
     }
 
     @Override

--- a/src/main/java/cli/rule/rules/TrailingRule.java
+++ b/src/main/java/cli/rule/rules/TrailingRule.java
@@ -14,6 +14,7 @@ import java.util.Set;
 public class TrailingRule implements IRestRule {
 
     private static final String TITLE = "A trailing forward slash (/) should not be included in URIs";
+    private static final RuleIdentifier RULE_IDENTIFIER = RuleIdentifier.TRAILING;
     private static final RuleCategory RULE_CATEGORY = RuleCategory.URIS;
     private static final RuleSeverity RULE_SEVERITY = RuleSeverity.ERROR;
     private static final List<RuleSoftwareQualityAttribute> SOFTWARE_QUALITY_ATTRIBUTES = List
@@ -27,6 +28,11 @@ public class TrailingRule implements IRestRule {
     @Override
     public String getTitle() {
         return TITLE;
+    }
+
+    @Override
+    public RuleIdentifier getIdentifier() {
+        return RULE_IDENTIFIER;
     }
 
     @Override

--- a/src/main/java/cli/rule/rules/TunnelingRule.java
+++ b/src/main/java/cli/rule/rules/TunnelingRule.java
@@ -15,6 +15,7 @@ import java.util.Map;
 public class TunnelingRule implements IRestRule {
 
     private static final String TITLE = "GET and POST must not be used to tunnel other request methods";
+    private static final RuleIdentifier RULE_IDENTIFIER = RuleIdentifier.TUNNELING;
     private static final RuleCategory RULE_CATEGORY = RuleCategory.HTTP;
     private static final RuleSeverity RULE_SEVERITY = RuleSeverity.CRITICAL;
     private static final List<RuleSoftwareQualityAttribute> SOFTWARE_QUALITY_ATTRIBUTES = List.of(
@@ -29,6 +30,11 @@ public class TunnelingRule implements IRestRule {
     @Override
     public String getTitle() {
         return TITLE;
+    }
+
+    @Override
+    public RuleIdentifier getIdentifier() {
+        return RULE_IDENTIFIER;
     }
 
     @Override

--- a/src/main/java/cli/rule/rules/UnauthorizedRule.java
+++ b/src/main/java/cli/rule/rules/UnauthorizedRule.java
@@ -24,6 +24,7 @@ import static cli.analyzer.RestAnalyzer.*;
 public class UnauthorizedRule implements IRestRule {
 
     private static final String TITLE = "401 (\"Unauthorized\") must be used when there is a problem with the client's credentials";
+    private static final RuleIdentifier RULE_IDENTIFIER = RuleIdentifier.UNAUTHORIZED;
     private static final RuleCategory CATEGORY = RuleCategory.HTTP;
     private static final RuleSeverity SEVERITY = RuleSeverity.CRITICAL;
     private static final List<RuleSoftwareQualityAttribute> SOFTWARE_QUALITY_ATTRIBUTE = Arrays.asList(
@@ -43,6 +44,11 @@ public class UnauthorizedRule implements IRestRule {
     @Override
     public String getTitle() {
         return TITLE;
+    }
+
+    @Override
+    public RuleIdentifier getIdentifier() {
+        return RULE_IDENTIFIER;
     }
 
     @Override

--- a/src/main/java/cli/rule/rules/UnderscoreRule.java
+++ b/src/main/java/cli/rule/rules/UnderscoreRule.java
@@ -18,6 +18,7 @@ import static cli.analyzer.RestAnalyzer.locMapper;
  */
 public class UnderscoreRule implements IRestRule {
     private static final String TITLE = "Underscores (_) should not be used in URI";
+    private static final RuleIdentifier RULE_IDENTIFIER = RuleIdentifier.UNDERSCORE;
     private static final RuleCategory CATEGORY = RuleCategory.URIS;
     private static final RuleSeverity SEVERITY = RuleSeverity.ERROR;
     private static final List<RuleSoftwareQualityAttribute> SOFTWARE_QUALITY_ATTRIBUTES = List
@@ -33,6 +34,11 @@ public class UnderscoreRule implements IRestRule {
     @Override
     public String getTitle() {
         return TITLE;
+    }
+
+    @Override
+    public RuleIdentifier getIdentifier() {
+        return RULE_IDENTIFIER;
     }
 
     @Override

--- a/src/main/java/cli/rule/rules/VerbPhraseRule.java
+++ b/src/main/java/cli/rule/rules/VerbPhraseRule.java
@@ -15,6 +15,7 @@ import cli.rule.Violation;
 import cli.rule.constants.ErrorMessage;
 import cli.rule.constants.ImprovementSuggestion;
 import cli.rule.constants.RuleCategory;
+import cli.rule.constants.RuleIdentifier;
 import cli.rule.constants.RuleSeverity;
 import cli.rule.constants.RuleSoftwareQualityAttribute;
 import cli.utility.Output;
@@ -25,6 +26,7 @@ import io.swagger.v3.oas.models.Paths;
 public class VerbPhraseRule implements IRestRule {
 
     private static final String TITLE = "A verb or verb phrase should be used for controller names";
+    private static final RuleIdentifier RULE_IDENTIFIER = RuleIdentifier.VERB_PHRASE;
     private static final RuleCategory RULE_CATEGORY = RuleCategory.URIS;
     private static final RuleSeverity RULE_SEVERITY = RuleSeverity.ERROR;
     private static final List<RuleSoftwareQualityAttribute> RULE_SOFTWARE_QUALITY_ATTRIBUTE_LIST =
@@ -41,6 +43,11 @@ public class VerbPhraseRule implements IRestRule {
     @Override
     public String getTitle() {
         return TITLE;
+    }
+
+    @Override
+    public RuleIdentifier getIdentifier() {
+        return RULE_IDENTIFIER;
     }
 
     @Override

--- a/src/main/java/cli/utility/Output.java
+++ b/src/main/java/cli/utility/Output.java
@@ -3,6 +3,7 @@ package cli.utility;
 import cli.rule.ActiveRules;
 import cli.analyzer.RestAnalyzer;
 import cli.rule.IRestRule;
+import cli.rule.constants.*;
 
 import java.io.File;
 import java.net.HttpURLConnection;
@@ -15,6 +16,15 @@ import java.util.*;
 public class Output {
     private static final String UNDERLINE = "----------------------------------------------";
     private final Scanner scanner = new Scanner(System.in);
+    private boolean useCamelCase = false;
+
+    /**
+     * Sets which naming convention rules should be active
+     * @param useCamelCase if true, enables camelCase rule and disables kebab-case rules
+     */
+    public void setNamingConventionRules(boolean useCamelCase) {
+        this.useCamelCase = useCamelCase;
+    }
 
     /**
      * Method for the expert mode. User will be asked to enable or disable each rule. The input will
@@ -101,7 +111,6 @@ public class Output {
      * @param generateReport if true, a report will be generated
      */
     public void startAnalysis(String pathToFile, boolean generateReport) {
-
         if (pathToFile.toLowerCase().startsWith("http") && !checkURL(pathToFile)) {
             System.err.println("The URL was not reachable. Please check the URL and try again.");
             return;
@@ -113,7 +122,30 @@ public class Output {
 
         RestAnalyzer restAnalyzer = new RestAnalyzer(pathToFile);
         printStartAnalysis(pathToFile);
-        restAnalyzer.runAnalyse(new ActiveRules().getAllRuleObjects(), generateReport);
+        
+        // Get rules and apply naming convention
+        ActiveRules activeRules = new ActiveRules();
+        List<IRestRule> ruleList = activeRules.getAllRuleObjects();
+        for (IRestRule rule : ruleList) {
+            RuleIdentifier ruleIdentifier = rule.getIdentifier();
+            if (useCamelCase) {
+                if (ruleIdentifier == RuleIdentifier.CAMEL_CASE) {
+                    rule.setIsActive(true);
+                } 
+                if (ruleIdentifier == RuleIdentifier.HYPHENS || ruleIdentifier == RuleIdentifier.LOWERCASE) {
+                    rule.setIsActive(false);
+                }
+            } else {
+                if (ruleIdentifier == RuleIdentifier.CAMEL_CASE) {
+                    rule.setIsActive(false);
+                } 
+                if (ruleIdentifier == RuleIdentifier.HYPHENS || ruleIdentifier == RuleIdentifier.LOWERCASE) {
+                    rule.setIsActive(true);
+                }
+            }
+        }
+        
+        restAnalyzer.runAnalyse(ruleList, generateReport);
     }
 
     /**
@@ -135,7 +167,30 @@ public class Output {
 
         RestAnalyzer restAnalyzer = new RestAnalyzer(pathToFile);
         printStartAnalysis(pathToFile);
-        restAnalyzer.runAnalyse(new ActiveRules().getAllRuleObjects(), title);
+        
+        // Get rules and apply naming convention
+        ActiveRules activeRules = new ActiveRules();
+        List<IRestRule> ruleList = activeRules.getAllRuleObjects();
+        for (IRestRule rule : ruleList) {
+            RuleIdentifier ruleIdentifier = rule.getIdentifier();
+            if (useCamelCase) {
+                if (ruleIdentifier == RuleIdentifier.CAMEL_CASE) {
+                    rule.setIsActive(true);
+                } 
+                if (ruleIdentifier == RuleIdentifier.HYPHENS || ruleIdentifier == RuleIdentifier.LOWERCASE) {
+                    rule.setIsActive(false);
+                }
+            } else {
+                if (ruleIdentifier == RuleIdentifier.CAMEL_CASE) {
+                    rule.setIsActive(false);
+                } 
+                if (ruleIdentifier == RuleIdentifier.HYPHENS || ruleIdentifier == RuleIdentifier.LOWERCASE) {
+                    rule.setIsActive(true);
+                }
+            }
+        }
+        
+        restAnalyzer.runAnalyse(ruleList, title);
     }
 
     /**

--- a/src/test/java/cli/rule/camelCaseTests/CamelCaseRuleTest.java
+++ b/src/test/java/cli/rule/camelCaseTests/CamelCaseRuleTest.java
@@ -1,0 +1,46 @@
+package cli.rule.camelCaseTests;
+
+import cli.analyzer.RestAnalyzer;
+import cli.rule.Violation;
+import cli.rule.rules.CamelCaseRule;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CamelCaseRuleTest {
+    CamelCaseRule camelCaseRule;
+    RestAnalyzer restAnalyzer;
+
+    @Test
+    @DisplayName("Test that checks if no camelCase rule violation is detected when there is a correct OpenAPI definition.")
+    void validFile() {
+        String url = "src/test/java/cli/validopenapi/validOpenAPI.json";
+        List<Violation> violations = runMethodUnderTest(url);
+        assertEquals(0, violations.size(), "There should be no rule violation for the valid openAPI definition.");
+    }
+
+    @Test
+    @DisplayName("Test that checks if camelCase rule violations are detected for paths with separators and incorrect casing.")
+    void invalidFile() {
+        String url = "src/test/java/cli/rule/camelCaseTests/camelCaseInvalid.json";
+        List<Violation> violations = runMethodUnderTest(url);
+        
+        // Expected violations:
+        // 1. /user-profile (contains hyphen)
+        // 2. /user_profile (contains underscore)
+        // 3. /UserProfile (starts with uppercase)
+        // 4. /userprofile (no camelCase for multi-word)
+        // 5. /book-author (contains hyphen)
+        // 6. /book_author (contains underscore)
+        assertEquals(6, violations.size(), "There should be 6 rule violations for paths with incorrect camelCase formatting.");
+    }
+
+    private List<Violation> runMethodUnderTest(String url) {
+        this.restAnalyzer = new RestAnalyzer(url);
+        this.camelCaseRule = new CamelCaseRule(true);
+        return this.restAnalyzer.runAnalyse(List.of(this.camelCaseRule), false);
+    }
+} 

--- a/src/test/java/cli/rule/camelCaseTests/camelCaseInvalid.json
+++ b/src/test/java/cli/rule/camelCaseTests/camelCaseInvalid.json
@@ -1,0 +1,89 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test API with camelCase violations",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/user-profile": {
+      "get": {
+        "summary": "Get user profile",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/user_profile": {
+      "get": {
+        "summary": "Get user profile",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/UserProfile": {
+      "get": {
+        "summary": "Get user profile",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/userprofile": {
+      "get": {
+        "summary": "Get user profile",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/userProfile": {
+      "get": {
+        "summary": "Get user profile",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/bookAuthor": {
+      "get": {
+        "summary": "Get book author",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/book-author": {
+      "get": {
+        "summary": "Get book author",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/book_author": {
+      "get": {
+        "summary": "Get book author",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+} 


### PR DESCRIPTION
# Description

Add an optional check for conformance to the camelCase naming convention. This rule originated from our interviews with various stakeholders regarding improvements that could be made to RESTRuler, and all 5 of the interviewees agreed that consistency is usually more important to them than specific rules. So they thought, instead of sticking to one pre-determined naming convention such as kebab-case, it would be fine as long as the API is consistent within itself. It would be worse for them if one URI followed the kebab-case convention whereas another URI in the same API followed camelCase. Therefore, this PR adds a camelCase rule that can be turned on via a flag. If the camelCase rule is turned on, the lowercase and hyphen rules are deactivated, as those rules would be mutually exclusive. The default remains to be kebab-case (usage of hyphens).

Additionally, to make it easier to deactivate rules based on the passed in naming convention flag, this PR adds a "rule identifier" to each rule, so we can directly identify and separate between the rules when deciding which ones should be turned off in a specific run.

## Type of change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [ ] Unit tests