### PR TITLE
feat: add the official http status codes rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -50,6 +50,7 @@ Documentation about the rules can be found in the [folder](./implemented-rules).
 * [A plural noun should be used for collection or store names](./implemented-rules/A-plural-noun-should-be-used-for-collection-or-store-names.md)
 * [A singular noun should be used for document names](./implemented-rules/A-singular-noun-should-be-used-for-document-names.md)
 * [A verb or verb phrase should be used for controller names](./implemented-rules/A-verb-or-verb-phrase-should-be-used-for-controller-names.md)
+* [Must use official HTTP status codes](./implemented-rules/Must-use-official-HTTP-status-codes.md)
 
 ### Rule implementation and extension
 For each rule, a single Java class is created, which can be found in in this [dir](../../src/main/java/cli/rule/rules). It is just as easy to implement a new rule. For implementing a new rule, it is merely necessary to create a Java class in the folder just mentioned, which implements the [`IRestRule`](../../src/main/java/cli/rule/IRestRule.java) interface. Then, a constructor with an `isActive` boolean is needed. Now the rule is automatically recognized and listed in the CLI. This is the minimum that needs to be done to implement a new rule. 

--- a/docs/rules/implemented-rules/Must-use-official-HTTP-status-codes.md
+++ b/docs/rules/implemented-rules/Must-use-official-HTTP-status-codes.md
@@ -1,0 +1,52 @@
+# Must use official HTTP status codes
+
+## Category
+
+HTTP
+
+## Importance, severity, difficulty
+
+* Importance: high
+* Severity: error
+* Difficulty to implement the rule: easy
+
+## Quality Attribute
+
+* Compatibility
+* Maintainability
+* Usability
+
+## Rule Description
+
+Description from Zalando [1].
+
+"You must only use official HTTP status codes consistently with their intended semantics. Official HTTP status codes are defined via RFC standards and registered in the IANA Status Code Registry."
+
+## Implemented
+
+* Y
+
+## Implementation Details
+
+### What is checked
+
+* Checks every response status code in the OpenAPI specification against the official IANA registry of HTTP status codes [2]
+* Validates that status codes are numeric (except for 'default' responses which are valid)
+* Ensures all status codes used are official codes from the IANA registry
+* Provides clear error messages indicating which status codes are not official or not numeric
+
+### What is not checked
+
+* The semantic meaning of the status codes (i.e., whether they are used appropriately for their intended purpose)
+* Custom status codes that might be valid for specific use cases but not in the IANA registry
+
+### Future work
+
+* Add validation of status code usage against their semantic meaning
+* Consider adding support for custom status codes with proper documentation
+* Add validation of status code consistency across similar operations
+
+## Source
+
+[1] https://opensource.zalando.com/restful-api-guidelines/#243  
+[2] https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml 

--- a/src/main/java/cli/rule/constants/ErrorMessage.java
+++ b/src/main/java/cli/rule/constants/ErrorMessage.java
@@ -22,6 +22,8 @@ public class ErrorMessage {
     public static final String REQUESTTYPE = "Type of the request does not match with the description of the request";
     public static final String REQUESTTYPETUNNELINGGET = "This request is performing more than one action. GET request should not be used to tunnel other request";
     public static final String REQUESTTYPETUNNELINGPOST = "This request is performing more than one action. POST request should not be used to tunnel other request";
+    public static final String HTTP_STATUS_CODE_NOT_OFFICIAL = "HTTP status code %d is not an official HTTP status code";
+    public static final String HTTP_STATUS_CODE_NOT_NUMERIC = "HTTP status code '%s' is not a numeric value";
 
 
     private ErrorMessage() {

--- a/src/main/java/cli/rule/rules/HTTPStatusRule.java
+++ b/src/main/java/cli/rule/rules/HTTPStatusRule.java
@@ -1,0 +1,139 @@
+package cli.rule.rules;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import cli.analyzer.RestAnalyzer;
+import cli.rule.IRestRule;
+import cli.rule.Violation;
+import cli.rule.constants.ErrorMessage;
+import cli.rule.constants.RuleCategory;
+import cli.rule.constants.RuleSeverity;
+import cli.rule.constants.RuleSoftwareQualityAttribute;
+import cli.utility.Output;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.Paths;
+
+
+/**
+ * Implementation of the rule: Must use official HTTP status codes.
+ */
+public class HTTPStatusRule implements IRestRule {
+    private static final String TITLE = "Must use official HTTP status codes";
+    private static final RuleCategory CATEGORY = RuleCategory.HTTP;
+    private static final RuleSeverity SEVERITY = RuleSeverity.ERROR;
+    private static final List<RuleSoftwareQualityAttribute> SOFTWARE_QUALITY_ATTRIBUTE = Arrays.asList(
+            RuleSoftwareQualityAttribute.COMPATIBILITY, RuleSoftwareQualityAttribute.MAINTAINABILITY,
+            RuleSoftwareQualityAttribute.USABILITY);
+    // source of truth for the codes here is: https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+    private static final Set<Integer> OFFICIAL_HTTP_STATUS_CODES = new HashSet<>(Arrays.asList(
+            100, 101, 102, 103, 104,
+            200, 201, 202, 203, 204, 205, 206, 207, 208, 226,
+            300, 301, 302, 303, 304, 305, 307, 308,
+            400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417,
+            421, 422, 423, 424, 425, 426, 428, 429, 431, 451,
+            500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511
+    ));
+    
+    private final List<Violation> violationList = new ArrayList<>();
+    private boolean isActive;
+
+    public HTTPStatusRule(boolean isActive) {
+        this.isActive = isActive;
+    }
+
+    @Override
+    public String getTitle() {
+        return TITLE;
+    }
+
+    @Override
+    public RuleCategory getCategory() {
+        return CATEGORY;
+    }
+
+    @Override
+    public RuleSeverity getSeverityType() {
+        return SEVERITY;
+    }
+
+    @Override
+    public List<RuleSoftwareQualityAttribute> getRuleSoftwareQualityAttribute() {
+        return SOFTWARE_QUALITY_ATTRIBUTE;
+    }
+
+    @Override
+    public boolean getIsActive() {
+        return this.isActive;
+    }
+
+    @Override
+    public void setIsActive(boolean isActive) {
+        this.isActive = isActive;
+    }
+
+    @Override
+    public List<Violation> checkViolation(OpenAPI openAPI) {
+        List<Violation> violationList = new ArrayList<>();
+        Paths paths = openAPI.getPaths();
+
+        if (paths == null) {
+            return violationList;
+        }
+
+        int curPath = 1;
+        int totalPaths = paths.keySet().size();
+
+        for (Map.Entry<String, PathItem> path : paths.entrySet()) {
+            Output.progressPercentage(curPath, totalPaths);
+            curPath++;
+
+            // get all operations for this path
+            for (Operation operation : path.getValue().readOperations()) {
+                if (operation.getResponses() == null) {
+                    continue;
+                }
+
+                for (Map.Entry<String, ApiResponse> response : operation.getResponses().entrySet()) {
+                    String statusCode = response.getKey();
+                    
+                    // skip 'default' responses as they are valid
+                    if (statusCode.equals("default")) {
+                        continue;
+                    }
+
+                    // check if the status code is numeric, if not it is a violation
+                    if (!statusCode.matches("\\d+")) {
+                        String message = String.format(ErrorMessage.HTTP_STATUS_CODE_NOT_NUMERIC, statusCode);
+                        violationList.add(new Violation(this,
+                            RestAnalyzer.locMapper.getLOCOfPath(path.getKey()),
+                            "Use a numeric HTTP status code from the IANA registry",
+                            path.getKey(),
+                            message));
+                        continue;
+                    }
+
+                    // now we know it's numeric, so we can safely parse it
+                    int code = Integer.parseInt(statusCode);
+                    if (!OFFICIAL_HTTP_STATUS_CODES.contains(code)) {
+                        String message = String.format(ErrorMessage.HTTP_STATUS_CODE_NOT_OFFICIAL,
+                                code, operation.getOperationId(), path.getKey());
+                        violationList.add(new Violation(this, 
+                            RestAnalyzer.locMapper.getLOCOfPath(path.getKey()),
+                            "Use an official HTTP status code from the IANA registry",
+                            path.getKey(),
+                            message));
+                    }
+                }
+            }
+        }
+
+        return violationList;
+    }
+}

--- a/src/test/java/cli/rule/httpStatusTest/HTTPStatusRuleTest.java
+++ b/src/test/java/cli/rule/httpStatusTest/HTTPStatusRuleTest.java
@@ -1,0 +1,46 @@
+package cli.rule.httpStatusTest;
+
+import cli.analyzer.RestAnalyzer;
+import cli.rule.Violation;
+import cli.rule.rules.HTTPStatusRule;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HTTPStatusRuleTest {
+    private RestAnalyzer restAnalyzer;
+    private HTTPStatusRule httpStatusRule;
+
+    @Test
+    @DisplayName("Test that checks if no violations are detected when using official HTTP status codes")
+    void validFile() {
+        String path = "src/test/java/cli/validopenapi/validOpenAPI.json";
+        List<Violation> violations = runMethodUnderTest(path);
+        assertEquals(0, violations.size(), "There should be no rule violations for valid HTTP status codes");
+    }
+
+    @Test
+    @DisplayName("Test that checks if violations are detected when using non-official HTTP status codes")
+    void invalidNonOfficialStatusCodes() {
+        String path = "src/test/java/cli/rule/httpStatusTest/InvalidOpenAPIHTTPStatusNonOfficial.json";
+        List<Violation> violations = runMethodUnderTest(path);
+        assertEquals(3, violations.size(), "There should be 3 violations for non-official HTTP status codes");
+    }
+
+    @Test
+    @DisplayName("Test that checks if violations are detected when using non-numeric status codes")
+    void invalidNonNumericStatusCodes() {
+        String path = "src/test/java/cli/rule/httpStatusTest/InvalidOpenAPIHTTPStatusNonNumeric.json";
+        List<Violation> violations = runMethodUnderTest(path);
+        assertEquals(2, violations.size(), "There should be 2 violations for non-numeric HTTP status codes");
+    }
+
+    private List<Violation> runMethodUnderTest(String url) {
+        this.restAnalyzer = new RestAnalyzer(url);
+        this.httpStatusRule = new HTTPStatusRule(true);
+        return this.restAnalyzer.runAnalyse(List.of(this.httpStatusRule), false);
+    }
+} 

--- a/src/test/java/cli/rule/httpStatusTest/InvalidOpenAPIHTTPStatusNonNumeric.json
+++ b/src/test/java/cli/rule/httpStatusTest/InvalidOpenAPIHTTPStatusNonNumeric.json
@@ -1,0 +1,87 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test API with non-numeric status codes",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "operationId": "getUsers",
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "success": {
+            "description": "Non-numeric status code"
+          },
+          "default": {
+            "description": "OK"
+          }
+        }
+      },
+      "post": {
+        "operationId": "createUser",
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "error": {
+            "description": "Another non-numeric status code"
+          }
+        }
+      }
+    },
+    "/movies": {
+        "post": {
+          "description": "Update a list of movies.",
+          "consumes": ["application/json"],
+          "parameters": [
+            {
+              "in": "body",
+              "name": "user",
+              "description": "The user to create.",
+              "schema": {
+                "type": "object",
+                "required": ["userName"],
+                "properties": {
+                  "userName": {
+                    "type": "string"
+                  },
+                  "firstName": {
+                    "type": "string"
+                  },
+                  "lastName": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "schema": {
+                "example": ["EURUSD", "GBPJPY", "AUDUSD"],
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "description": "OK"
+            },
+            "default": {
+              "schema": {
+                "example": ["EURUSD", "GBPJPY", "AUDUSD"],
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            }
+          },
+          "summary": "Publish a message to a channel",
+          "tags": ["Publishing"]
+        }
+      }
+  }
+} 

--- a/src/test/java/cli/rule/httpStatusTest/InvalidOpenAPIHTTPStatusNonOfficial.json
+++ b/src/test/java/cli/rule/httpStatusTest/InvalidOpenAPIHTTPStatusNonOfficial.json
@@ -1,0 +1,46 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test API with non-official status codes",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "operationId": "getUsers",
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "999": {
+            "description": "Non-official status code"
+          }
+        }
+      },
+      "post": {
+        "operationId": "createUser",
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "888": {
+            "description": "Another non-official status code"
+          }
+        }
+      }
+    },
+    "/users/{id}": {
+      "get": {
+        "operationId": "getUserById",
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "777": {
+            "description": "Yet another non-official status code"
+          }
+        }
+      }
+    }
+  }
+} 

--- a/src/test/java/cli/validopenapi/validOpenAPI.json
+++ b/src/test/java/cli/validopenapi/validOpenAPI.json
@@ -207,7 +207,7 @@
           }
         ],
         "responses": {
-          "2XX": {
+          "200": {
             "schema": {
               "example": ["EURUSD", "GBPJPY", "AUDUSD"],
               "items": {


### PR DESCRIPTION
# Description

This PR adds a new rule that checks whether each HTTP status code that is used in the responses of a URI is an official code or not.

## Type of change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [ ] Unit tests