### PR TITLE
feat: add normalized path segments rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -52,6 +52,7 @@ Documentation about the rules can be found in the [folder](./implemented-rules).
 * [A verb or verb phrase should be used for controller names](./implemented-rules/A-verb-or-verb-phrase-should-be-used-for-controller-names.md)
 * [Camel case should be used (optional)](./implemented-rules/Camel-case-should-be-used.md)
 * [Must use official HTTP status codes](./implemented-rules/Must-use-official-HTTP-status-codes.md)
+* [Must use normalized paths without empty path segments](./implemented-rules/Must-use-normalized-paths.md)
 
 ### Rule implementation and extension
 For each rule, a single Java class is created, which can be found in in this [dir](../../src/main/java/cli/rule/rules). It is just as easy to implement a new rule. For implementing a new rule, it is merely necessary to create a Java class in the folder just mentioned, which implements the [`IRestRule`](../../src/main/java/cli/rule/IRestRule.java) interface. Then, a constructor with an `isActive` boolean is needed. Now the rule is automatically recognized and listed in the CLI. This is the minimum that needs to be done to implement a new rule. 

--- a/docs/rules/implemented-rules/Must-use-normalized-paths.md
+++ b/docs/rules/implemented-rules/Must-use-normalized-paths.md
@@ -1,0 +1,47 @@
+# Must use normalized paths without empty path segments
+
+## Category
+
+HTTP
+
+## Importance, severity, difficulty
+
+* Importance: medium
+* Severity: error
+* Difficulty to implement the rule: easy
+
+## Quality Attribute
+
+* Compatibility
+* Maintainability
+
+## Rule Description
+
+Description from Zalando [1].
+
+"You must not specify paths with duplicate or trailing slashes, e.g. /customers//addresses or /customers/. As a consequence, you must also not specify or use path variables with empty string values."
+
+## Implemented
+
+* Y
+
+## Implementation Details
+
+### What is checked
+
+* Checks every path in the OpenAPI spec
+* Validates that there are no empty path segments in each URI
+* Provides clear error messages if an empty path segment is detected
+
+### What is not checked
+
+* Presence of more than one empty path segments in a URI (should occur very very rarely anyway)
+* Presence of multiple slashes chained together (e.g., //// etc.)
+
+### Future work
+
+* --
+
+## Source
+
+[1] https://opensource.zalando.com/restful-api-guidelines/#136

--- a/src/main/java/cli/rule/constants/ErrorMessage.java
+++ b/src/main/java/cli/rule/constants/ErrorMessage.java
@@ -25,6 +25,7 @@ public class ErrorMessage {
     public static final String CAMELCASE = "Multi-word URI segment does not follow camelCase convention";
     public static final String HTTP_STATUS_CODE_NOT_OFFICIAL = "HTTP status code %d is not an official HTTP status code";
     public static final String HTTP_STATUS_CODE_NOT_NUMERIC = "HTTP status code '%s' is not a numeric value";
+    public static final String EMPTYPATHSEGMENT = "Path contains empty segments (//) which violates the path normalization rule.";
 
 
     private ErrorMessage() {

--- a/src/main/java/cli/rule/constants/RuleIdentifier.java
+++ b/src/main/java/cli/rule/constants/RuleIdentifier.java
@@ -18,4 +18,5 @@ public enum RuleIdentifier {
     UNDERSCORE,
     VERB_PHRASE,
     OFFICIAL_HTTP_STATUS_CODES,
+    NORMALIZED_PATHS,
 }

--- a/src/main/java/cli/rule/rules/NormalizedPathsRule.java
+++ b/src/main/java/cli/rule/rules/NormalizedPathsRule.java
@@ -1,0 +1,92 @@
+package cli.rule.rules;
+
+import cli.rule.constants.*;
+import io.swagger.v3.oas.models.OpenAPI;
+import cli.rule.IRestRule;
+import cli.rule.Violation;
+import cli.utility.Output;
+import cli.rule.constants.ErrorMessage;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static cli.analyzer.RestAnalyzer.locMapper;
+
+/**
+ * RULE: Must use normalized paths without empty path segments
+ */
+public class NormalizedPathsRule implements IRestRule {
+    private static final String TITLE = "Must use normalized paths without empty path segments";
+    private static final RuleIdentifier RULE_IDENTIFIER = RuleIdentifier.NORMALIZED_PATHS;
+    private static final RuleCategory RULE_CATEGORY = RuleCategory.URIS;
+    private static final RuleSeverity RULE_SEVERITY = RuleSeverity.ERROR;
+    private static final List<RuleSoftwareQualityAttribute> SOFTWARE_QUALITY_ATTRIBUTES = List
+            .of(RuleSoftwareQualityAttribute.MAINTAINABILITY, RuleSoftwareQualityAttribute.COMPATIBILITY);
+    private boolean isActive;
+
+    public NormalizedPathsRule(boolean isActive) {
+        this.isActive = isActive;
+    }
+
+    @Override
+    public String getTitle() {
+        return TITLE;
+    }
+
+    @Override
+    public RuleIdentifier getIdentifier() {
+        return RULE_IDENTIFIER;
+    }
+
+    @Override
+    public RuleCategory getCategory() {
+        return RULE_CATEGORY;
+    }
+
+    @Override
+    public RuleSeverity getSeverityType() {
+        return RULE_SEVERITY;
+    }
+
+    @Override
+    public List<RuleSoftwareQualityAttribute> getRuleSoftwareQualityAttribute() {
+        return SOFTWARE_QUALITY_ATTRIBUTES;
+    }
+
+    @Override
+    public boolean getIsActive() {
+        return this.isActive;
+    }
+
+    @Override
+    public void setIsActive(boolean isActive) {
+        this.isActive = isActive;
+    }
+
+    @Override
+    public List<Violation> checkViolation(OpenAPI openAPI) {
+        List<Violation> violations = new ArrayList<>();
+        Set<String> paths = openAPI.getPaths().keySet();
+
+        if (paths.isEmpty()) {
+            return violations;
+        }
+
+        int curPath = 1;
+        int totalPaths = paths.size();
+
+        for (String path : paths) {
+            Output.progressPercentage(curPath, totalPaths);
+            curPath++;
+
+            // check for empty path segments (//)
+            if (path.contains("//")) {
+                violations.add(new Violation(this, locMapper.getLOCOfPath(path),
+                        "Path contains empty segments. Normalize the path by removing empty segments.",
+                        path, ErrorMessage.EMPTYPATHSEGMENT));
+            }
+        }
+
+        return violations;
+    }
+}

--- a/src/test/java/cli/rule/normalizedPathsTest/InvalidOpenAPINormalizedPathsRule.json
+++ b/src/test/java/cli/rule/normalizedPathsTest/InvalidOpenAPINormalizedPathsRule.json
@@ -1,0 +1,49 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test API with non-normalized paths",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/valid/path": {
+      "get": {
+        "summary": "Valid path",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/invalid//path": {
+      "get": {
+        "summary": "Invalid path with empty segment",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/another//invalid//path": {
+      "get": {
+        "summary": "Invalid path with multiple empty segments",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/invalid/path//with//empty/segments": {
+      "get": {
+        "summary": "Invalid path with empty segments in the middle",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+} 

--- a/src/test/java/cli/rule/normalizedPathsTest/NormalizedPathsRuleTest.java
+++ b/src/test/java/cli/rule/normalizedPathsTest/NormalizedPathsRuleTest.java
@@ -1,0 +1,36 @@
+package cli.rule.normalizedPathsTest;
+
+import cli.analyzer.RestAnalyzer;
+import cli.rule.Violation;
+import cli.rule.rules.NormalizedPathsRule;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class NormalizedPathsRuleTest {
+    RestAnalyzer restAnalyzer;
+    NormalizedPathsRule normalizedPathsRule;
+
+    @Test
+    @DisplayName("Test that checks if no violation is detected when there is a correct OpenAPI definition.")
+    void validFile() {
+        List<Violation> violations = runMethodUnderTest("src/test/java/cli/validopenapi/validOpenAPI.json");
+        assertEquals(0, violations.size(), "There should be no rule violation for the valid openAPI definition.");
+    }
+
+    @Test
+    @DisplayName("Test that checks if the normalized paths rule violations are detected.")
+    void invalidFile() {
+        List<Violation> violations = runMethodUnderTest("src/test/java/cli/rule/normalizedPathsTest/InvalidOpenAPINormalizedPathsRule.json");
+        assertEquals(3, violations.size(), "There should be 3 rule violations for paths containing empty segments.");
+    }
+
+    private List<Violation> runMethodUnderTest(String url) {
+        this.restAnalyzer = new RestAnalyzer(url);
+        this.normalizedPathsRule = new NormalizedPathsRule(true);
+        return this.restAnalyzer.runAnalyse(List.of(this.normalizedPathsRule), false);
+    }
+}


### PR DESCRIPTION
# Description

This PR adds a new rule to check whether each URI in an API is normalized (doesn't contain empty path segments).

## Type of change

Please delete options that are not relevant.
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [ ] Unit tests
