### PR TITLE
feat: add meta information rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -53,6 +53,7 @@ Documentation about the rules can be found in the [folder](./implemented-rules).
 * [Camel case should be used (optional)](./implemented-rules/Camel-case-should-be-used.md)
 * [Must use official HTTP status codes](./implemented-rules/Must-use-official-HTTP-status-codes.md)
 * [Must use normalized paths without empty path segments](./implemented-rules/Must-use-normalized-paths.md)
+* [Must contain API meta information](./implemented-rules/Must-contain-API-meta-information.md)
 
 ### Rule implementation and extension
 For each rule, a single Java class is created, which can be found in in this [dir](../../src/main/java/cli/rule/rules). It is just as easy to implement a new rule. For implementing a new rule, it is merely necessary to create a Java class in the folder just mentioned, which implements the [`IRestRule`](../../src/main/java/cli/rule/IRestRule.java) interface. Then, a constructor with an `isActive` boolean is needed. Now the rule is automatically recognized and listed in the CLI. This is the minimum that needs to be done to implement a new rule. 

--- a/docs/rules/implemented-rules/Must-contain-API-meta-information.md
+++ b/docs/rules/implemented-rules/Must-contain-API-meta-information.md
@@ -1,0 +1,54 @@
+# Must contain API meta information
+
+## Category
+
+META
+
+## Importance, severity, difficulty
+
+* Importance: medium
+* Severity: warning
+* Difficulty to implement the rule: easy
+
+## Quality Attribute
+
+* Maintainability
+* Usability
+
+## Rule Description
+
+Description from Zalando [1].
+
+"API specifications must contain the following OpenAPI meta information to allow for API management:
+
+#/info/title as (unique) identifying, functional descriptive name of the API
+
+#/info/version to distinguish API specifications versions following semantic rules
+
+#/info/description containing a proper description of the API
+
+#/info/contact/{name,url,email} containing the responsible team"
+
+## Implemented
+
+* Y
+
+## Implementation Details
+
+### What is checked
+
+* Checks the info field of an OpenAPI spec
+* Checks whether the `title`, `version`, `description`, and `contact/{name, url, email}` fields are populated
+* Provides clear error messages if any of the fields are missing/empty
+
+### What is not checked
+
+* Other information components (such as `x-api-id` or `x-audience` etc.)
+
+### Future work
+
+* More fields that are required for clear documentation may be identified and checked
+
+## Source
+
+[1] https://opensource.zalando.com/restful-api-guidelines/#218

--- a/src/main/java/cli/rule/constants/ErrorMessage.java
+++ b/src/main/java/cli/rule/constants/ErrorMessage.java
@@ -26,6 +26,7 @@ public class ErrorMessage {
     public static final String HTTP_STATUS_CODE_NOT_OFFICIAL = "HTTP status code %d is not an official HTTP status code";
     public static final String HTTP_STATUS_CODE_NOT_NUMERIC = "HTTP status code '%s' is not a numeric value";
     public static final String EMPTYPATHSEGMENT = "Path contains empty segments (//) which violates the path normalization rule.";
+    public static final String METAINFO = "Make sure to include title, version, description, name, URL, and email in the information field of the API";
 
 
     private ErrorMessage() {

--- a/src/main/java/cli/rule/constants/RuleIdentifier.java
+++ b/src/main/java/cli/rule/constants/RuleIdentifier.java
@@ -19,4 +19,5 @@ public enum RuleIdentifier {
     VERB_PHRASE,
     OFFICIAL_HTTP_STATUS_CODES,
     NORMALIZED_PATHS,
+    META_INFO,
 }

--- a/src/main/java/cli/rule/rules/MetaInfoRule.java
+++ b/src/main/java/cli/rule/rules/MetaInfoRule.java
@@ -1,0 +1,121 @@
+package cli.rule.rules;
+
+import cli.rule.IRestRule;
+import cli.rule.Violation;
+import cli.rule.constants.*;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class implements the Rule "MUST contain API meta information"
+ */
+public class MetaInfoRule implements IRestRule {
+    private static final String TITLE = "OpenAPI specification must contain required meta information";
+    private static final RuleIdentifier RULE_IDENTIFIER = RuleIdentifier.META_INFO;
+    private static final RuleCategory RULE_CATEGORY = RuleCategory.META;
+    private static final RuleSeverity RULE_SEVERITY = RuleSeverity.WARNING;
+    private static final List<RuleSoftwareQualityAttribute> SOFTWARE_QUALITY_ATTRIBUTES = List.of(
+            RuleSoftwareQualityAttribute.MAINTAINABILITY,
+            RuleSoftwareQualityAttribute.USABILITY
+    );
+    private boolean isActive;
+
+    public MetaInfoRule(boolean isActive) {
+        this.isActive = isActive;
+    }
+
+    @Override
+    public String getTitle() {
+        return TITLE;
+    }
+
+    @Override
+    public RuleIdentifier getIdentifier() {
+        return RULE_IDENTIFIER;
+    }
+
+    @Override
+    public RuleCategory getCategory() {
+        return RULE_CATEGORY;
+    }
+
+    @Override
+    public RuleSeverity getSeverityType() {
+        return RULE_SEVERITY;
+    }
+
+    @Override
+    public List<RuleSoftwareQualityAttribute> getRuleSoftwareQualityAttribute() {
+        return SOFTWARE_QUALITY_ATTRIBUTES;
+    }
+
+    @Override
+    public boolean getIsActive() {
+        return this.isActive;
+    }
+
+    @Override
+    public void setIsActive(boolean isActive) {
+        this.isActive = isActive;
+    }
+    
+    /**
+     * Checks if there is a violation against the "MUST contain API meta information" rule
+     * To conform to the rule, multiple fields within the "info" field of the API must be provided
+     * The rule ensures an API's meta information is adequately documented
+     *
+     * @param openAPI the definition that will be checked against the rule.
+     * @return the list of violations.
+     */
+    @Override
+    public List<Violation> checkViolation(OpenAPI openAPI) {
+        List<Violation> violations = new ArrayList<>();
+
+        Info info = openAPI.getInfo();
+        if (info == null) {
+            violations.add(new Violation(this, 0, "Add an 'info' object to the OpenAPI specification", 
+                "info", ErrorMessage.METAINFO));
+            return violations;
+        }
+
+        if (info.getTitle() == null || info.getTitle().trim().isEmpty()) {
+            violations.add(new Violation(this, 0, "Add a title to the info object", 
+                "info.title", ErrorMessage.METAINFO));
+        }
+
+        if (info.getVersion() == null || info.getVersion().trim().isEmpty()) {
+            violations.add(new Violation(this, 0, "Add a version to the info object", 
+                "info.version", ErrorMessage.METAINFO));
+        }
+
+        if (info.getDescription() == null || info.getDescription().trim().isEmpty()) {
+            violations.add(new Violation(this, 0, "Add a description to the info object", 
+                "info.description", ErrorMessage.METAINFO));
+        }
+
+        Contact contact = info.getContact();
+        if (contact == null) {
+            violations.add(new Violation(this, 0, "Add a contact object to the info object", 
+                "info.contact", ErrorMessage.METAINFO));
+        } else {
+            if (contact.getName() == null || contact.getName().trim().isEmpty()) {
+                violations.add(new Violation(this, 0, "Add a name to the contact object", 
+                    "info.contact.name", ErrorMessage.METAINFO));
+            }
+            if (contact.getUrl() == null || contact.getUrl().trim().isEmpty()) {
+                violations.add(new Violation(this, 0, "Add a URL to the contact object", 
+                    "info.contact.url", ErrorMessage.METAINFO));
+            }
+            if (contact.getEmail() == null || contact.getEmail().trim().isEmpty()) {
+                violations.add(new Violation(this, 0, "Add an email to the contact object", 
+                    "info.contact.email", ErrorMessage.METAINFO));
+            }
+        }
+
+        return violations;
+    }
+} 

--- a/src/test/java/cli/rule/metaInfoTest/InvalidOpenAPIMetaInfoRule.json
+++ b/src/test/java/cli/rule/metaInfoTest/InvalidOpenAPIMetaInfoRule.json
@@ -1,0 +1,56 @@
+{
+  "swagger": "2.0",
+  "schemes": ["https", "http"],
+  "host": "1forge.com",
+  "basePath": "/forex-quotes",
+  "info": {
+    "contact": {
+      "name": "",
+      "url": ""
+    },
+    "description": "",
+    "title": "",
+    "version": "1.0"
+  },
+  "produces": ["application/json"],
+  "paths": {
+    "/quotes": {
+      "get": {
+        "description": "Get quotes",
+        "externalDocs": {
+          "description": "Find out more",
+          "url": "http://1forge.com/forex-data-api"
+        },
+        "security": [
+          {
+            "OAuth2": ["read"]
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "example": ["EURUSD", "GBPJPY", "AUDUSD"],
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "description": "A list of quotes"
+          },
+          "401": {
+            "schema": {
+              "example": ["EURUSD", "GBPJPY", "AUDUSD"],
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "description": "Unauthorized"
+          }
+        },
+        "summary": "Get quotes for all symbols",
+        "tags": ["forex", "finance", "quotes"]
+      }
+    }
+  }
+} 

--- a/src/test/java/cli/rule/metaInfoTest/MetaInfoRuleTest.java
+++ b/src/test/java/cli/rule/metaInfoTest/MetaInfoRuleTest.java
@@ -1,0 +1,38 @@
+package cli.rule.metaInfoTest;
+
+import cli.analyzer.RestAnalyzer;
+import cli.rule.Violation;
+import cli.rule.rules.MetaInfoRule;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MetaInfoRuleTest {
+    private static final String PATH_INVALID_OPENAPI = "src/test/java/cli/rule/metaInfoTest/InvalidOpenAPIMetaInfoRule.json";
+    private static final String VALID_OPENAPI = "src/test/java/cli/validopenapi/validOpenAPI.json";
+    RestAnalyzer restAnalyzer;
+    MetaInfoRule metaInfoRule;
+
+    @Test
+    @DisplayName("Test that checks if no meta info rule violation is detected when there is a correct OpenAPI definition.")
+    void validFile() {
+        List<Violation> violations = runMethodUnderTest(VALID_OPENAPI);
+        assertEquals(0, violations.size(), "There should be no rule violation for the valid openAPI definition.");
+    }
+
+    @Test
+    @DisplayName("Test that checks if meta info rule violations are detected when required meta information is missing.")
+    void invalidFile() {
+        List<Violation> violations = runMethodUnderTest(PATH_INVALID_OPENAPI);
+        assertEquals(5, violations.size(), "There should be 5 rule violations for missing meta information.");
+    }
+
+    private List<Violation> runMethodUnderTest(String url) {
+        this.restAnalyzer = new RestAnalyzer(url);
+        this.metaInfoRule = new MetaInfoRule(true);
+        return this.restAnalyzer.runAnalyse(List.of(this.metaInfoRule), false);
+    }
+} 


### PR DESCRIPTION
# Description

This PR adds a new rule that checks whether each API has a meta information field with certain information filled in. This information is important to ensure the API is adequately documented.

## Type of change

Please delete options that are not relevant.
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [ ] Unit tests
