### PR TITLE
feat: utilize the OpenAI API for tunneling detection

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,6 +18,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
     steps:
     - uses: actions/checkout@v3
     - name: Set up JDK

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation("org.atteo:evo-inflector:1.3")
     implementation("org.apache.opennlp:opennlp-tools:2.3.0")
     implementation("nz.ac.waikato.cms.weka:weka-stable:3.8.6")
+    implementation("com.openai:openai-java:1.6.1")
 }
 
 shadowJar {

--- a/src/main/java/cli/RestRulerCli.java
+++ b/src/main/java/cli/RestRulerCli.java
@@ -28,6 +28,10 @@ public class RestRulerCli implements Runnable {
             description = "Specify the naming convention to use (camelcase or kebabcase). Default is kebabcase.")
     private String namingConvention;
 
+    @Option(names = {"-llm", "--enableExternalLLM"},
+        description = "Enable the usage of LLMs for the evaluation of some rules.")
+    private boolean enableLLM;
+
     public static void main(String[] args) {
         PicocliRunner.run(RestRulerCli.class, args);
     }
@@ -46,7 +50,7 @@ public class RestRulerCli implements Runnable {
             } else {
                 output.setNamingConventionRules(false);
             }
-
+            output.setEnableLLM(this.enableLLM);
             if (filename != null)
                 output.startAnalysis(this.openApiPath, this.filename);
             else

--- a/src/main/java/cli/ai/gpt.java
+++ b/src/main/java/cli/ai/gpt.java
@@ -1,0 +1,100 @@
+package cli.ai;
+
+import cli.analyzer.RestAnalyzer;
+import cli.rule.IRestRule;
+import cli.rule.Violation;
+import cli.rule.constants.*;
+import com.openai.client.OpenAIClient;
+import com.openai.client.okhttp.OpenAIOkHttpClient;
+import com.openai.models.ChatModel;
+import com.openai.models.responses.Response;
+import com.openai.models.responses.ResponseCreateParams;
+
+import java.util.List;
+
+// gpt is a class that brings together the LLM-related functionality in the CLI
+// different rules may use the methods in this class to establish a connection to an external LLM agent for rule evaluation
+public class gpt {
+    private OpenAIClient client;
+
+    private final String modelNoResponse = "no";
+    
+    private final String systemMessageTunneling = """
+        You are a REST API design validator. Your task is to determine whether HTTP method tunneling is present in a given endpoint.
+
+        An endpoint is considered to be tunneling if it uses a certain HTTP method to perform actions that are more appropriately represented by another HTTP method.
+
+        HTTP Method Definitions (use these exact criteria):
+        - POST must be used to create a new resource in a collection or to execute controllers and not for other purposes
+        - GET must be used to retrieve a representation of a resource and not for other purposes
+        - DELETE should be used to delete a resource and not for other purposes
+        - PUT must be used to both insert and update a stored resource and not for other purposes
+
+        If the actual HTTP method does not align with the conventional RESTful method implied by the endpoint's summary or description, classify it as tunneling.
+
+        Only respond with a one-word valid method name (one of POST, GET, DELETE or PUT) or "No" if no violation is detected.
+        Do not explain your reasoning.
+
+        Examples:
+
+        Method: POST  
+        Description: Update a list.  
+        Summary: Update a list based on input.
+        Response: PUT
+
+        Method: PUT  
+        Description: Submit a new application for review.  
+        Summary: Create a new application  
+        Response: POST
+
+        Method: DELETE  
+        Description: Deactivate a user account.  
+        Summary: Soft delete a user  
+        Response: No
+        """;
+    
+    public gpt() {
+        this.client = OpenAIOkHttpClient.fromEnv();
+    }
+
+    public void tunnelingViolationAI(IRestRule rule, String keyPath, String description, String summary,
+    String requestType, String requestTypeMessage, String improvement, List<Violation> violations) {
+        String input = this.constructTunnelingInput(description, summary, requestType);
+        ResponseCreateParams params = ResponseCreateParams.builder()
+        .temperature(0)
+        .instructions(this.systemMessageTunneling)
+        .input(input)
+        .model(ChatModel.GPT_4_1_MINI)
+        .build();
+        Response response = this.client.responses().create(params);
+
+        response.output().stream()
+                .flatMap(item -> item.message().stream())
+                .flatMap(message -> message.content().stream())
+                .flatMap(content -> content.outputText().stream())
+                .forEach(outputText -> {
+                    String output = outputText.text();
+
+                    if (!output.toLowerCase().equals(this.modelNoResponse) && !output.toUpperCase().equals(requestType.toUpperCase())) {
+                        violations.add(new Violation(rule, RestAnalyzer.locMapper.getLOCOfPath(keyPath),
+                                requestTypeMessage + improvement + output,
+                                keyPath,
+                                ErrorMessage.REQUESTTYPE));
+                    }
+                });
+    }
+
+    private String constructTunnelingInput(String description, String summary, String requestType) {
+        String res = String.format("Method: %s", requestType);
+
+        if (description != null && !description.isEmpty()) {
+            res += String.format("\nDescription: %s", description);
+        }
+
+        if (summary != null && !summary.isEmpty()) {
+            res += String.format("\nSummary: %s", summary);
+        }
+
+        return res;
+    }
+}

--- a/src/main/java/cli/rule/IRestRule.java
+++ b/src/main/java/cli/rule/IRestRule.java
@@ -23,6 +23,14 @@ public interface IRestRule {
     boolean getIsActive();
 
     void setIsActive(boolean isActive);
+    
+    /**
+     * Method used to determine whether the rule will use an LLM-based approach during evaluation.
+     * This method is only used by rules that actually have an LLM component, so not every rule needs to implement a body for this.
+     *
+     * @param enableLLM determines whether LLM usage is enabled or not
+     */
+    default void setEnableLLM(boolean enableLLM) {}
 
     /**
      * Method used to check for any violations of the implemented rule

--- a/src/main/java/cli/utility/Output.java
+++ b/src/main/java/cli/utility/Output.java
@@ -17,6 +17,7 @@ public class Output {
     private static final String UNDERLINE = "----------------------------------------------";
     private final Scanner scanner = new Scanner(System.in);
     private boolean useCamelCase = false;
+    private boolean enableLLM = false;
 
     /**
      * Sets which naming convention rules should be active
@@ -24,6 +25,14 @@ public class Output {
      */
     public void setNamingConventionRules(boolean useCamelCase) {
         this.useCamelCase = useCamelCase;
+    }
+
+    /**
+     * Toggles flag to enable the usage of LLMs in some rules
+     * @param enableLLM if true, enables the usage of LLMs
+     */
+    public void setEnableLLM(boolean enableLLM) {
+        this.enableLLM = enableLLM;
     }
 
     /**
@@ -128,6 +137,11 @@ public class Output {
         List<IRestRule> ruleList = activeRules.getAllRuleObjects();
         for (IRestRule rule : ruleList) {
             RuleIdentifier ruleIdentifier = rule.getIdentifier();
+
+            if (ruleIdentifier == RuleIdentifier.REQUEST_TYPE_DESCRIPTION) {
+                rule.setEnableLLM(this.enableLLM);
+            }
+
             if (useCamelCase) {
                 if (ruleIdentifier == RuleIdentifier.CAMEL_CASE) {
                     rule.setIsActive(true);
@@ -173,6 +187,11 @@ public class Output {
         List<IRestRule> ruleList = activeRules.getAllRuleObjects();
         for (IRestRule rule : ruleList) {
             RuleIdentifier ruleIdentifier = rule.getIdentifier();
+
+            if (ruleIdentifier == RuleIdentifier.REQUEST_TYPE_DESCRIPTION) {
+                rule.setEnableLLM(this.enableLLM);
+            }
+
             if (useCamelCase) {
                 if (ruleIdentifier == RuleIdentifier.CAMEL_CASE) {
                     rule.setIsActive(true);

--- a/src/test/java/cli/rule/requestTypeDescriptionTest/RequestTypeDescriptionTest.java
+++ b/src/test/java/cli/rule/requestTypeDescriptionTest/RequestTypeDescriptionTest.java
@@ -21,9 +21,21 @@ public class RequestTypeDescriptionTest {
 
         String url = "src/test/java/cli/rule/requestTypeDescriptionTest/requestTypeDescription2Violations.json";
 
-        List<Violation> violationToTest = runMethodUnderTest(url);
+        List<Violation> violationToTest = runMethodUnderTest(url, false);
 
-        assertEquals(8, violationToTest.size(),
+        assertEquals(9, violationToTest.size(),
+                "Detection of violations should work.");
+    }
+
+    @Test
+    @DisplayName("Detect if a path segment contains a violation regarding the store or collection name using an LLM")
+    void checkViolationOnInvalidRESTFile2ViolationsAI() throws MalformedURLException {
+
+        String url = "src/test/java/cli/rule/requestTypeDescriptionTest/requestTypeDescription2Violations.json";
+
+        List<Violation> violationToTest = runMethodUnderTest(url, true);
+
+        assertEquals(13, violationToTest.size(),
                 "Detection of violations should work.");
     }
 
@@ -32,16 +44,31 @@ public class RequestTypeDescriptionTest {
     void checkViolationOnValidRESTFile() throws MalformedURLException {
 
         String url = "src/test/java/cli/validopenapi/validOpenAPI.json";
-        List<Violation> violationToTest = runMethodUnderTest(url);
+        List<Violation> violationToTest = runMethodUnderTest(url, false);
 
         assertEquals(0, violationToTest.size(),
                 "Detection of violations should work.");
     }
 
-    private List<Violation> runMethodUnderTest(String url) throws MalformedURLException {
+    @Test
+    @DisplayName("Test a valid api with an LLM. No error should be detected.")
+    void checkViolationOnValidRESTFileAI() throws MalformedURLException {
+
+        String url = "src/test/java/cli/validopenapi/validOpenAPI.json";
+        List<Violation> violationToTest = runMethodUnderTest(url, true);
+
+        assertEquals(0, violationToTest.size(),
+                "Detection of violations should work.");
+    }
+
+    private List<Violation> runMethodUnderTest(String url, boolean enableLLM) throws MalformedURLException {
 
         this.restAnalyzer = new RestAnalyzer(url);
         this.requestTypeDescriptionRuleTest = new RequestTypeDescriptionRule(true);
+
+        if (enableLLM) {
+            this.requestTypeDescriptionRuleTest.setEnableLLM(enableLLM);
+        }
 
         return this.restAnalyzer.runAnalyse(List.of(this.requestTypeDescriptionRuleTest), false);
     }

--- a/src/test/java/cli/rule/requestTypeDescriptionTest/requestTypeDescription2Violations.json
+++ b/src/test/java/cli/rule/requestTypeDescriptionTest/requestTypeDescription2Violations.json
@@ -53,6 +53,24 @@
           "finance",
           "quotes"
         ]
+      },
+      "post": {
+        "description": "Delete quotes",
+        "externalDocs": {
+          "description": "Find out more",
+          "url": "http://1forge.com/forex-data-api"
+        },
+        "responses": {
+          "200": {
+            "description": "A list of quotes"
+          }
+        },
+        "summary": "Delete quotes for all symbols",
+        "tags": [
+          "forex",
+          "finance",
+          "quotes"
+        ]
       }
     },
     "/symbols": {

--- a/src/test/java/cli/validopenapi/validOpenAPI.json
+++ b/src/test/java/cli/validopenapi/validOpenAPI.json
@@ -181,7 +181,7 @@
       }
     },
     "/movies": {
-      "post": {
+      "put": {
         "description": "Update a list of movies.",
         "consumes": ["application/json"],
         "parameters": [
@@ -227,7 +227,6 @@
             }
           }
         },
-        "summary": "Publish a message to a channel",
         "tags": ["Publishing"]
       }
     }


### PR DESCRIPTION
# Description
This PR adds a new `-llm` flag to the CLI, that allows users to toggle the usage of AI for certain rules. We also implemented AI usage in the rule `Description of request should match with the type of the request` (essentially `no tunneling`). We leverage the OpenAI API to send the necessary context to ChatGPT, and receive a response indicating whether tunneling has occurred for a certain path in the API or not. Users can opt to turn the AI integration on or off via the flag (the default is off, where the custom ML model is used instead). 

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [ ] Unit tests
- [ ] Benchmarked for effectiveness here: https://github.com/restful-ma/rest-ruler-evaluation/pull/3
