### PR TITLE
feat: utilize the OpenAI API for plural name detection in collection or store names

### DIFF
--- a/src/main/java/cli/ai/gpt.java
+++ b/src/main/java/cli/ai/gpt.java
@@ -8,9 +8,10 @@ import com.openai.client.OpenAIClient;
 import com.openai.client.okhttp.OpenAIOkHttpClient;
 import com.openai.models.ChatModel;
 import com.openai.models.responses.Response;
+import cli.utility.Output;
 import com.openai.models.responses.ResponseCreateParams;
 
-import java.util.List;
+import java.util.*;
 
 // gpt is a class that brings together the LLM-related functionality in the CLI
 // different rules may use the methods in this class to establish a connection to an external LLM agent for rule evaluation
@@ -53,35 +54,154 @@ public class gpt {
         Response: No
         """;
     
+    private final String systemMessagePluralName = """
+        You are a REST API design validator. Your task is to determine whether a given URI violates the rule of alternating between singular and plural nouns. You must analyze each segment of the URI to check for violations.
+
+        Rule Definition:
+        The segments in a URI must alternate between singular and plural nouns. No two adjacent segments can both be singular or both be plural.
+
+        Valid patterns:
+
+        singular / plural / singular / plural / ...
+
+        plural / singular / plural / singular / ...
+
+        Evaluation Process:
+
+        Split the URI into its segments (between slashes).
+
+        Label each segment as singular or plural using the rules below.
+
+        Evaluate the list of labels in order.
+
+        If any two adjacent segments are both singular or both plural, this is a violation.
+
+        Classification Rules:
+
+        Path Parameters (enclosed in {}):
+        Always treated as singular
+        Example: {userId} = singular
+
+        Compound Words:
+        Use the final word to determine plurality. Compound words could be separated by dashes or just be one block consisting of two words.
+
+        user-profiles → plural (ends in "profiles")
+
+        information-item → singular (ends in "item")
+
+        example-cases → plural (ends in "cases")
+
+        transactionRules → plural (ends in "Rules")
+
+        Special Words - Interchangeable: Words that only have singular forms (e.g., "information", "advice", "equipment", "furniture", "luggage") or only have plural forms (e.g., "jeans", "trousers", "pants", "scissors", "glasses", "clothes") are INTERCHANGEABLE. They can be treated as either singular or plural depending on what's needed to maintain the alternating pattern:
+        "information" can be treated as singular OR plural
+        "jeans" can be treated as singular OR plural
+        "species" (same singular/plural form) can be treated as singular OR plural
+
+        Abbreviations & Acronyms:
+        Treated as singular unless clearly known to be plural (e.g., IDs)
+
+        Violation Conditions:
+        A violation occurs if:
+
+        Two singular segments appear consecutively
+
+        Two plural segments appear consecutively
+
+        Two path parameters appear consecutively
+
+        Examples:
+
+        URI: /enterprises/enterprise/people/person
+        Labels: plural / singular / plural / singular
+        Output: No
+
+        URI: /store/{storeId}/books
+        Labels: singular / singular / plural
+        Output: Yes
+
+        URI: /users/{userId}/{profileId}
+        Labels: plural / singular / singular
+        Output: Yes
+
+        URI: /activities/{id}/participant
+        Labels: plural / singular / singular
+        Output: Yes
+
+        URI: /items/person/book
+        Labels: plural / singular / singular
+        Output: Yes
+
+        URI: /schools/{student}/books
+        Labels: plural / singular / plural
+        Output: No
+
+        URI: /adults/{get_adult_ID}/names
+        Labels: plural / singular / plural
+        Output: No
+
+        URI: /information-item/{informationId}
+        Labels: singular / singular
+        Output: Yes
+
+        URI: /cases-high-prio/{caseId}
+        Labels: singular / singular
+        Output: Yes
+
+        URI: /people/{person}/student
+        Labels: plural / singular / singular
+        Output: Yes
+
+        URI: /person/{person}
+        Labels: singular / singular
+        Output: Yes
+
+        URI: /information/{informationId}
+        Labels: plural (next node is singular, so treat as plural) / singular (path parameters are always singular)
+        Output: No
+
+        URI: /orgs/{org}/action/secret/{secret_name}/repositories/{repository_id}
+        Labels: plural / singular / singular / singular / singular / plural / singular
+        Output: Yes
+
+        Instructions:
+        Only reply with "Yes" if a violation is detected, or "No" if there is no violation. Do not explain your reasoning. Follow the rules and examples strictly. Apply reasoning to the entire URI and check each pair of segments.
+        """;
+    
     public gpt() {
         this.client = OpenAIOkHttpClient.fromEnv();
     }
 
     public void tunnelingViolationAI(IRestRule rule, String keyPath, String description, String summary,
     String requestType, String requestTypeMessage, String improvement, List<Violation> violations) {
-        String input = this.constructTunnelingInput(description, summary, requestType);
-        ResponseCreateParams params = ResponseCreateParams.builder()
-        .temperature(0)
-        .instructions(this.systemMessageTunneling)
-        .input(input)
-        .model(ChatModel.GPT_4_1_MINI)
-        .build();
-        Response response = this.client.responses().create(params);
+        try {
+            String input = this.constructTunnelingInput(description, summary, requestType);
+            ResponseCreateParams params = ResponseCreateParams.builder()
+            .temperature(0)
+            .instructions(this.systemMessageTunneling)
+            .input(input)
+            .model(ChatModel.GPT_4_1_MINI)
+            .build();
+            Response response = this.client.responses().create(params);
 
-        response.output().stream()
-                .flatMap(item -> item.message().stream())
-                .flatMap(message -> message.content().stream())
-                .flatMap(content -> content.outputText().stream())
-                .forEach(outputText -> {
-                    String output = outputText.text();
+            response.output().stream()
+                    .flatMap(item -> item.message().stream())
+                    .flatMap(message -> message.content().stream())
+                    .flatMap(content -> content.outputText().stream())
+                    .forEach(outputText -> {
+                        String output = outputText.text();
 
-                    if (!output.toLowerCase().equals(this.modelNoResponse) && !output.toUpperCase().equals(requestType.toUpperCase())) {
-                        violations.add(new Violation(rule, RestAnalyzer.locMapper.getLOCOfPath(keyPath),
-                                requestTypeMessage + improvement + output,
-                                keyPath,
-                                ErrorMessage.REQUESTTYPE));
-                    }
-                });
+                        if (!output.toLowerCase().equals(this.modelNoResponse) && !output.toUpperCase().equals(requestType.toUpperCase())) {
+                            violations.add(new Violation(rule, RestAnalyzer.locMapper.getLOCOfPath(keyPath),
+                                    requestTypeMessage + improvement + output,
+                                    keyPath,
+                                    ErrorMessage.REQUESTTYPE));
+                        }
+                    });
+        } catch (Exception e) {
+            // Log the error but don't crash the analysis
+            System.err.println("GPT API error for " + keyPath + ": " + e.getMessage());
+        }
     }
 
     private String constructTunnelingInput(String description, String summary, String requestType) {
@@ -96,5 +216,49 @@ public class gpt {
         }
 
         return res;
+    }
+
+    public List<Violation> pluralNameAI(IRestRule rule, List<Violation> violations, Set<String> paths) {
+        int curPath = 1;
+        int totalPaths = paths.size();
+        for (String path : paths) {
+            Output.progressPercentage(curPath, totalPaths);;
+            
+            if (path.trim().equals("")) {
+                continue;
+            }
+            
+            try {
+                ResponseCreateParams params = ResponseCreateParams.builder()
+                .temperature(0)
+                .instructions(this.systemMessagePluralName)
+                .input(path)
+                .model(ChatModel.GPT_4_1_MINI)
+                .build();
+                
+                Response response = this.client.responses().create(params);
+        
+                response.output().stream()
+                        .flatMap(item -> item.message().stream())
+                        .flatMap(message -> message.content().stream())
+                        .flatMap(content -> content.outputText().stream())
+                        .forEach(outputText -> {
+                            String output = outputText.text();
+        
+                            if (!output.toLowerCase().equals(this.modelNoResponse)) {
+                                violations.add(new Violation(rule, RestAnalyzer.locMapper.getLOCOfPath(path),
+                                ImprovementSuggestion.PLURAL_NAME,
+                                        path,
+                                        ErrorMessage.PLURAL_NAME));
+                            }
+                        });
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            
+            curPath++;
+        }
+
+        return violations;
     }
 }

--- a/src/main/java/cli/rule/rules/PluralNameRule.java
+++ b/src/main/java/cli/rule/rules/PluralNameRule.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import cli.rule.IRestRule;
 import cli.rule.Violation;
 import cli.utility.Output;
+import cli.ai.gpt;
 
 import java.util.*;
 
@@ -21,9 +22,12 @@ public class PluralNameRule implements IRestRule {
     private static final List<RuleSoftwareQualityAttribute> RULE_SOFTWARE_QUALITY_ATTRIBUTE_LIST = List
             .of(RuleSoftwareQualityAttribute.USABILITY, RuleSoftwareQualityAttribute.MAINTAINABILITY);
     private boolean isActive;
+    private gpt gptClient;
+    private boolean enableLLM = false;
 
     public PluralNameRule(boolean isActive) {
         this.isActive = isActive;
+        this.gptClient = new gpt();
     }
 
     @Override
@@ -57,6 +61,11 @@ public class PluralNameRule implements IRestRule {
     }
 
     @Override
+    public void setEnableLLM(boolean enableLLM) {
+        this.enableLLM = enableLLM;
+    }
+
+    @Override
     public void setIsActive(boolean isActive) {
         this.isActive = isActive;
     }
@@ -71,6 +80,9 @@ public class PluralNameRule implements IRestRule {
         if (paths.isEmpty())
             return violations;
         // Loop through the paths
+        if (this.enableLLM) {
+            return this.gptClient.pluralNameAI(this, violations, paths);
+        }
         return getLstViolations(violations, paths);
     }
 

--- a/src/main/java/cli/utility/Output.java
+++ b/src/main/java/cli/utility/Output.java
@@ -141,6 +141,9 @@ public class Output {
             if (ruleIdentifier == RuleIdentifier.REQUEST_TYPE_DESCRIPTION) {
                 rule.setEnableLLM(this.enableLLM);
             }
+            if (ruleIdentifier == RuleIdentifier.PLURAL_NAME) {
+                rule.setEnableLLM(this.enableLLM);
+            }
 
             if (useCamelCase) {
                 if (ruleIdentifier == RuleIdentifier.CAMEL_CASE) {
@@ -189,6 +192,9 @@ public class Output {
             RuleIdentifier ruleIdentifier = rule.getIdentifier();
 
             if (ruleIdentifier == RuleIdentifier.REQUEST_TYPE_DESCRIPTION) {
+                rule.setEnableLLM(this.enableLLM);
+            }
+            if (ruleIdentifier == RuleIdentifier.PLURAL_NAME) {
                 rule.setEnableLLM(this.enableLLM);
             }
 

--- a/src/test/java/cli/rule/pluralNameTest/PluralNameTest.java
+++ b/src/test/java/cli/rule/pluralNameTest/PluralNameTest.java
@@ -23,7 +23,19 @@ public class PluralNameTest {
 
         String url = "src/test/java/cli/rule/pluralNameTest/pluralName4Violations.json";
 
-        List<Violation> violationToTest = runMethodUnderTest(url);
+        List<Violation> violationToTest = runMethodUnderTest(url, false);
+
+        assertEquals(4, violationToTest.size(),
+                "Detection of violations should work.");
+    }
+
+    @Test
+    @DisplayName("Detect if a path segment contains a violation regarding the store or collection name using an LLM")
+    void checkViolationOnInvalidRESTFile2ViolationsLLM() throws MalformedURLException {
+
+        String url = "src/test/java/cli/rule/pluralNameTest/pluralName4Violations.json";
+
+        List<Violation> violationToTest = runMethodUnderTest(url, true);
 
         assertEquals(4, violationToTest.size(),
                 "Detection of violations should work.");
@@ -34,16 +46,31 @@ public class PluralNameTest {
     void checkViolationOnValidRESTFile() throws MalformedURLException {
 
         String url = "src/test/java/cli/validopenapi/validOpenAPI.json";
-        List<Violation> violationToTest = runMethodUnderTest(url);
+        List<Violation> violationToTest = runMethodUnderTest(url, false);
 
         assertEquals(0, violationToTest.size(),
                 "Detection of violations should work.");
     }
 
-    private List<Violation> runMethodUnderTest(String url) throws MalformedURLException {
+    @Test
+    @DisplayName("Test a valid api with an LLM. No error should be detected.")
+    void checkViolationOnValidRESTFileLLM() throws MalformedURLException {
+
+        String url = "src/test/java/cli/validopenapi/validOpenAPI.json";
+        List<Violation> violationToTest = runMethodUnderTest(url, true);
+
+        assertEquals(0, violationToTest.size(),
+                "Detection of violations should work.");
+    }
+
+    private List<Violation> runMethodUnderTest(String url, boolean enableLLM) throws MalformedURLException {
 
         this.restAnalyzer = new RestAnalyzer(url);
         this.pluralNameRuleTest = new PluralNameRule(true);
+
+        if (enableLLM) {
+            this.pluralNameRuleTest.setEnableLLM(enableLLM);
+        }
 
         return this.restAnalyzer.runAnalyse(List.of(this.pluralNameRuleTest), false);
     }


### PR DESCRIPTION
# Description
In this PR, we implemented AI usage in the rule `A plural noun should be used for collection or store names`. We leverage the OpenAI API to send the necessary context to ChatGPT, and receive a response indicating whether tunneling has occurred for a certain path in the API or not. Users can opt to turn the AI integration on or off via the flag (the default is off, where the custom ML model is used instead).

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [ ] Unit tests
- [ ] Benchmarked for effectiveness here: https://github.com/restful-ma/rest-ruler-evaluation/pull/4